### PR TITLE
Adding GitHub Actions workflow for building the application using Java 8

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,34 @@
+name: Build
+
+on:
+  push:
+    branches:
+      - '*'
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    name: "Build with ${{ matrix.java }}"
+    strategy:
+      matrix:
+        java: [ 8 ]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Setup java ${{ matrix.java }}
+        uses: actions/setup-java@v1
+        with:
+          java-version: ${{ matrix.java }}
+
+      - name: Cache local Maven repository
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+
+      - name: Build with Maven
+        run: ./mvnw clean verify


### PR DESCRIPTION
I was a happy user of TravisCI, but lately I have been experiencing very flaky behaviour such as receiving Build Failed error emails while the build is still going on and then received Build success emails.

Then, I switched to use GH Actions and I am very happy with its consistency and there are lot of capabilities built-in and from community to do wide variety of things. Also, no need to switch between GitHub and TravisCI to check the build status, everything is at one place.

This PR adds GitHub Actions workflow to build and test the application on every push to any branch. I hope its useful.