### PR TITLE
Look throw class hierarchy to find the HttpStatus and the Error Code

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     </parent>
     <groupId>io.github.wimdeblauwe</groupId>
     <artifactId>error-handling-spring-boot-starter</artifactId>
-    <version>1.5.0</version>
+    <version>1.6.0-SNAPSHOT</version>
     <name>Error Handling Spring Boot Starter</name>
     <description>Spring Boot starter that configures error handling</description>
 
@@ -50,7 +50,7 @@
         </developerConnection>
         <connection>scm:git:git@github.com:wimdeblauwe/error-handling-spring-boot-starter.git</connection>
         <url>git@github.com:wimdeblauwe/error-handling-spring-boot-starter.git</url>
-        <tag>1.5.0</tag>
+        <tag>HEAD</tag>
     </scm>
     <issueManagement>
         <system>github</system>

--- a/src/main/java/io/github/wimdeblauwe/errorhandlingspringbootstarter/DefaultFallbackApiExceptionHandler.java
+++ b/src/main/java/io/github/wimdeblauwe/errorhandlingspringbootstarter/DefaultFallbackApiExceptionHandler.java
@@ -128,7 +128,24 @@ public class DefaultFallbackApiExceptionHandler implements FallbackApiExceptionH
             return ((ResponseStatusException) exception).getStatus();
         }
 
-        return properties.getHttpStatuses().getOrDefault(exception.getClass().getName(), HttpStatus.INTERNAL_SERVER_ERROR);
+        // Find the first existing HttpStatus code throw the class hierarchy.
+        HttpStatus status = getHttpStatus(exception.getClass());
+        if (status != null) {
+            return status;
+        }
+        // If not found return default
+        return HttpStatus.INTERNAL_SERVER_ERROR;
+    }
+
+    private HttpStatus getHttpStatus(Class<?> exceptionClass) {
+        if (exceptionClass == null) {
+            return null;
+        }
+        String className = exceptionClass.getName();
+        if (properties.getHttpStatuses().containsKey(className)) {
+            return properties.getHttpStatuses().get(className);
+        }
+        return getHttpStatus(exceptionClass.getSuperclass());
     }
 
     private String getErrorCode(Throwable exception) {


### PR DESCRIPTION
This allows to define an override for the `HttpStatus` for any **Exception** class in a class hierarchy.

For example, you could have some exceptions like `com.acme.EntiyOneNotFoundException` and `com.acme.EntityTwoNotFoundExtension` both of them extending `com.acme.NotFoundException`.

Now you can set the same `HttpStatus` for any child of `com.acme.NotFoundException` by specifying:

`error.handling.http-statuses.com.acme.NotFoundException=not_found`

If there is a new `com.acme.EntityThreeNotFoundException` it also "inherits" it's "ancestor" `HttpStatus`, but you could set:

`error.handling.http-statuses.com.acme.EntityThreeNotFoundException=bad_request`

and that would "override" it's parent settings.