### PR TITLE
Look throw class hierarchy to find the overrides

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -549,6 +549,43 @@ This results in:
 ----
 <.> Custom error message used in the response
 
+=== Super class hierarchy search
+
+By default, the library will only match <<HTTP response status>>, <<Error codes>> or <<Error messages>> settings in the properties when there is an exact match with the full qualified name of the `Exception`.
+
+If you want to define settings for a group of Exceptions that share a common superclass, then this is possible by enabling the `error.handling.search-super-class-hierarchy` setting:
+
+[source,properties]
+----
+error.handling.search-super-class-hierarchy=true
+----
+
+With this in place, we can for instance set the properties for any `RuntimeException` sub-class like this:
+
+[source,properties]
+----
+error.handling.http-statuses.java.lang.RuntimeException=bad_request
+error.handling.codes.java.lang.RuntimeException=RUNTIME_EXCEPTION
+error.handling.messages.java.lang.RuntimeException=A runtime exception has happened
+----
+
+Assume this exception is thrown:
+
+[source,java]
+----
+public class MyException extends RuntimeException {}
+----
+
+Then the response will be:
+
+[source,json]
+----
+{
+  "code": "RUNTIME_EXCEPTION",
+  "message": "A runtime exception has happened"
+}
+----
+
 === Exception handlers
 
 ==== Validation
@@ -1068,6 +1105,11 @@ One of `FULL_QUALIFIED_NAME`, `ALL_CAPS`.
 |error.handling.messages
 |Allows to set the message that should be used for the full qualified name of an `Exception` or the name of a validation annotation.
 |
+
+|error.handling.search-super-class-hierarchy
+|By default, only the exact full qualified name of an `Exception` is searched for when setting `error.handling.http-statuses`, `error.handling.codes` or `error.handling.messages`.
+When this is set to `true`, you can use any superclass from your `Exception` type as well.
+|`false`
 
 |error.handling.json-field-names.code
 |The field name that is used to serialize the `code` to JSON.

--- a/src/main/java/io/github/wimdeblauwe/errorhandlingspringbootstarter/ErrorHandlingProperties.java
+++ b/src/main/java/io/github/wimdeblauwe/errorhandlingspringbootstarter/ErrorHandlingProperties.java
@@ -30,6 +30,8 @@ public class ErrorHandlingProperties {
 
     private Map<String, String> messages = new HashMap<>();
 
+    private boolean searchSuperClassHierarchy = false;
+
     public boolean isEnabled() {
         return enabled;
     }
@@ -100,6 +102,14 @@ public class ErrorHandlingProperties {
 
     public void setMessages(Map<String, String> messages) {
         this.messages = messages;
+    }
+
+    public boolean isSearchSuperClassHierarchy() {
+        return searchSuperClassHierarchy;
+    }
+
+    public void setSearchSuperClassHierarchy(boolean searchSuperClassHierarchy) {
+        this.searchSuperClassHierarchy = searchSuperClassHierarchy;
     }
 
     enum ExceptionLogging {

--- a/src/main/java/io/github/wimdeblauwe/errorhandlingspringbootstarter/mapper/ErrorCodeMapper.java
+++ b/src/main/java/io/github/wimdeblauwe/errorhandlingspringbootstarter/mapper/ErrorCodeMapper.java
@@ -1,10 +1,11 @@
 package io.github.wimdeblauwe.errorhandlingspringbootstarter.mapper;
 
-import io.github.wimdeblauwe.errorhandlingspringbootstarter.ErrorHandlingProperties;
-import io.github.wimdeblauwe.errorhandlingspringbootstarter.ResponseErrorCode;
+import java.util.Locale;
+
 import org.springframework.core.annotation.AnnotationUtils;
 
-import java.util.Locale;
+import io.github.wimdeblauwe.errorhandlingspringbootstarter.ErrorHandlingProperties;
+import io.github.wimdeblauwe.errorhandlingspringbootstarter.ResponseErrorCode;
 
 /**
  * This class contains the logic for getting the matching error code for the given {@link Throwable}.
@@ -54,7 +55,7 @@ public class ErrorCodeMapper {
         return result;
     }
 
-    private String getErrorCodeFromPropertiesOrAnnotation(Class<? extends Throwable> exceptionClass) {
+    private String getErrorCodeFromPropertiesOrAnnotation(Class<?> exceptionClass) {
         if (exceptionClass == null) {
             return null;
         }
@@ -66,13 +67,7 @@ public class ErrorCodeMapper {
         if (errorCodeAnnotation != null) {
             return errorCodeAnnotation.value();
         }
-        Class<?> superClass = exceptionClass.getSuperclass();
-        if (Throwable.class.isAssignableFrom(superClass)) {
-            @SuppressWarnings("unchecked") Class<? extends Throwable> superThrowable = (Class<? extends Throwable>) superClass;
-            return getErrorCodeFromPropertiesOrAnnotation(superThrowable);
-        } else {
-            return null;
-        }
+        return getErrorCodeFromPropertiesOrAnnotation(exceptionClass.getSuperclass());
     }
 
 }

--- a/src/main/java/io/github/wimdeblauwe/errorhandlingspringbootstarter/mapper/ErrorCodeMapper.java
+++ b/src/main/java/io/github/wimdeblauwe/errorhandlingspringbootstarter/mapper/ErrorCodeMapper.java
@@ -1,11 +1,10 @@
 package io.github.wimdeblauwe.errorhandlingspringbootstarter.mapper;
 
-import java.util.Locale;
-
-import org.springframework.core.annotation.AnnotationUtils;
-
 import io.github.wimdeblauwe.errorhandlingspringbootstarter.ErrorHandlingProperties;
 import io.github.wimdeblauwe.errorhandlingspringbootstarter.ResponseErrorCode;
+import org.springframework.core.annotation.AnnotationUtils;
+
+import java.util.Locale;
 
 /**
  * This class contains the logic for getting the matching error code for the given {@link Throwable}.
@@ -19,7 +18,7 @@ public class ErrorCodeMapper {
     }
 
     public String getErrorCode(Throwable exception) {
-         String code = getErrorCodeFromPropertiesOrAnnotation(exception.getClass());
+        String code = getErrorCodeFromPropertiesOrAnnotation(exception.getClass());
         if (code != null) {
             return code;
         }
@@ -67,7 +66,12 @@ public class ErrorCodeMapper {
         if (errorCodeAnnotation != null) {
             return errorCodeAnnotation.value();
         }
-        return getErrorCodeFromPropertiesOrAnnotation(exceptionClass.getSuperclass());
+
+        if (properties.isSearchSuperClassHierarchy()) {
+            return getErrorCodeFromPropertiesOrAnnotation(exceptionClass.getSuperclass());
+        } else {
+            return null;
+        }
     }
 
 }

--- a/src/main/java/io/github/wimdeblauwe/errorhandlingspringbootstarter/mapper/ErrorMessageMapper.java
+++ b/src/main/java/io/github/wimdeblauwe/errorhandlingspringbootstarter/mapper/ErrorMessageMapper.java
@@ -13,26 +13,11 @@ public class ErrorMessageMapper {
     }
 
     public String getErrorMessage(Throwable exception) {
-         // Find the first existing message override throw the class hierarchy
-         String code = getErrorMessage(exception.getClass());
+         String code = getErrorMessageFromProperties(exception.getClass());
         if (code != null) {
             return code;
         }
-        // If not found return the exception mesage
         return exception.getMessage();
-    }
-
-    public String getErrorMessage(Class<?> exceptionClass) {
-        if (exceptionClass == null) {
-            return null;
-        }
-        // Check if a property overriding exisits
-        String exceptionClassName = exceptionClass.getName();
-        if (properties.getMessages().containsKey(exceptionClassName)) {
-            return properties.getMessages().get(exceptionClassName);
-        }
-        // If not, check ancestor
-        return getErrorMessage(exceptionClass.getSuperclass());
     }
 
     public String getErrorMessage(String fieldSpecificCode, String code, String defaultMessage) {
@@ -49,5 +34,22 @@ public class ErrorMessageMapper {
         }
 
         return defaultMessage;
+    }
+
+    private String getErrorMessageFromProperties(Class<? extends Throwable> exceptionClass) {
+        if (exceptionClass == null) {
+            return null;
+        }
+        String exceptionClassName = exceptionClass.getName();
+        if (properties.getMessages().containsKey(exceptionClassName)) {
+            return properties.getMessages().get(exceptionClassName);
+        }
+        Class<?> superClass = exceptionClass.getSuperclass();
+        if (Throwable.class.isAssignableFrom(superClass)) {
+            @SuppressWarnings("unchecked") Class<? extends Throwable> superThrowable = (Class<? extends Throwable>) superClass;
+            return getErrorMessageFromProperties(superThrowable);
+        } else {
+            return null;
+        }
     }
 }

--- a/src/main/java/io/github/wimdeblauwe/errorhandlingspringbootstarter/mapper/ErrorMessageMapper.java
+++ b/src/main/java/io/github/wimdeblauwe/errorhandlingspringbootstarter/mapper/ErrorMessageMapper.java
@@ -36,7 +36,7 @@ public class ErrorMessageMapper {
         return defaultMessage;
     }
 
-    private String getErrorMessageFromProperties(Class<? extends Throwable> exceptionClass) {
+    private String getErrorMessageFromProperties(Class<?> exceptionClass) {
         if (exceptionClass == null) {
             return null;
         }
@@ -44,12 +44,6 @@ public class ErrorMessageMapper {
         if (properties.getMessages().containsKey(exceptionClassName)) {
             return properties.getMessages().get(exceptionClassName);
         }
-        Class<?> superClass = exceptionClass.getSuperclass();
-        if (Throwable.class.isAssignableFrom(superClass)) {
-            @SuppressWarnings("unchecked") Class<? extends Throwable> superThrowable = (Class<? extends Throwable>) superClass;
-            return getErrorMessageFromProperties(superThrowable);
-        } else {
-            return null;
-        }
+        return getErrorMessageFromProperties(exceptionClass.getSuperclass());
     }
 }

--- a/src/main/java/io/github/wimdeblauwe/errorhandlingspringbootstarter/mapper/ErrorMessageMapper.java
+++ b/src/main/java/io/github/wimdeblauwe/errorhandlingspringbootstarter/mapper/ErrorMessageMapper.java
@@ -12,13 +12,27 @@ public class ErrorMessageMapper {
         this.properties = properties;
     }
 
-    public String getErrorMessage(Throwable throwable) {
-        String exceptionClassName = throwable.getClass().getName();
+    public String getErrorMessage(Throwable exception) {
+         // Find the first existing message override throw the class hierarchy
+         String code = getErrorMessage(exception.getClass());
+        if (code != null) {
+            return code;
+        }
+        // If not found return the exception mesage
+        return exception.getMessage();
+    }
+
+    public String getErrorMessage(Class<?> exceptionClass) {
+        if (exceptionClass == null) {
+            return null;
+        }
+        // Check if a property overriding exisits
+        String exceptionClassName = exceptionClass.getName();
         if (properties.getMessages().containsKey(exceptionClassName)) {
             return properties.getMessages().get(exceptionClassName);
         }
-
-        return throwable.getMessage();
+        // If not, check ancestor
+        return getErrorMessage(exceptionClass.getSuperclass());
     }
 
     public String getErrorMessage(String fieldSpecificCode, String code, String defaultMessage) {

--- a/src/main/java/io/github/wimdeblauwe/errorhandlingspringbootstarter/mapper/ErrorMessageMapper.java
+++ b/src/main/java/io/github/wimdeblauwe/errorhandlingspringbootstarter/mapper/ErrorMessageMapper.java
@@ -13,7 +13,7 @@ public class ErrorMessageMapper {
     }
 
     public String getErrorMessage(Throwable exception) {
-         String code = getErrorMessageFromProperties(exception.getClass());
+        String code = getErrorMessageFromProperties(exception.getClass());
         if (code != null) {
             return code;
         }
@@ -44,6 +44,10 @@ public class ErrorMessageMapper {
         if (properties.getMessages().containsKey(exceptionClassName)) {
             return properties.getMessages().get(exceptionClassName);
         }
-        return getErrorMessageFromProperties(exceptionClass.getSuperclass());
+        if (properties.isSearchSuperClassHierarchy()) {
+            return getErrorMessageFromProperties(exceptionClass.getSuperclass());
+        } else {
+            return null;
+        }
     }
 }

--- a/src/main/java/io/github/wimdeblauwe/errorhandlingspringbootstarter/mapper/HttpStatusMapper.java
+++ b/src/main/java/io/github/wimdeblauwe/errorhandlingspringbootstarter/mapper/HttpStatusMapper.java
@@ -1,11 +1,10 @@
 package io.github.wimdeblauwe.errorhandlingspringbootstarter.mapper;
 
+import io.github.wimdeblauwe.errorhandlingspringbootstarter.ErrorHandlingProperties;
 import org.springframework.core.annotation.AnnotationUtils;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.server.ResponseStatusException;
-
-import io.github.wimdeblauwe.errorhandlingspringbootstarter.ErrorHandlingProperties;
 
 /**
  * This class contains the logic for getting the matching HTTP Status for the given {@link Throwable}.
@@ -48,7 +47,11 @@ public class HttpStatusMapper {
             return responseStatus.value();
         }
 
-        return getHttpStatusFromPropertiesOrAnnotation(exceptionClass.getSuperclass());
+        if (properties.isSearchSuperClassHierarchy()) {
+            return getHttpStatusFromPropertiesOrAnnotation(exceptionClass.getSuperclass());
+        } else {
+            return null;
+        }
     }
 
 }

--- a/src/main/java/io/github/wimdeblauwe/errorhandlingspringbootstarter/mapper/HttpStatusMapper.java
+++ b/src/main/java/io/github/wimdeblauwe/errorhandlingspringbootstarter/mapper/HttpStatusMapper.java
@@ -1,10 +1,11 @@
 package io.github.wimdeblauwe.errorhandlingspringbootstarter.mapper;
 
-import io.github.wimdeblauwe.errorhandlingspringbootstarter.ErrorHandlingProperties;
 import org.springframework.core.annotation.AnnotationUtils;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.server.ResponseStatusException;
+
+import io.github.wimdeblauwe.errorhandlingspringbootstarter.ErrorHandlingProperties;
 
 /**
  * This class contains the logic for getting the matching HTTP Status for the given {@link Throwable}.
@@ -33,7 +34,7 @@ public class HttpStatusMapper {
         return defaultHttpStatus;
     }
 
-    private HttpStatus getHttpStatusFromPropertiesOrAnnotation(Class<? extends Throwable> exceptionClass) {
+    private HttpStatus getHttpStatusFromPropertiesOrAnnotation(Class<?> exceptionClass) {
         if (exceptionClass == null) {
             return null;
         }
@@ -47,13 +48,7 @@ public class HttpStatusMapper {
             return responseStatus.value();
         }
 
-        Class<?> superClass = exceptionClass.getSuperclass();
-        if (Throwable.class.isAssignableFrom(superClass)) {
-            @SuppressWarnings("unchecked") Class<? extends Throwable> superThrowable = (Class<? extends Throwable>) superClass;
-            return getHttpStatusFromPropertiesOrAnnotation(superThrowable);
-        } else {
-            return null;
-        }
+        return getHttpStatusFromPropertiesOrAnnotation(exceptionClass.getSuperclass());
     }
 
 }

--- a/src/test/java/io/github/wimdeblauwe/errorhandlingspringbootstarter/DefaultFallbackApiExceptionHandlerTest.java
+++ b/src/test/java/io/github/wimdeblauwe/errorhandlingspringbootstarter/DefaultFallbackApiExceptionHandlerTest.java
@@ -59,6 +59,29 @@ class DefaultFallbackApiExceptionHandlerTest {
             ApiErrorResponse response = handler.handle(exception);
             assertThat(response.getHttpStatus()).isEqualTo(HttpStatus.I_AM_A_TEAPOT);
         }
+
+        @Test
+        void propertiesConfigurationInSuperClass() {
+            ErrorHandlingProperties properties = new ErrorHandlingProperties();
+            properties.setSearchSuperClassHierarchy(true);
+            properties.getHttpStatuses().put(RuntimeException.class.getName(), HttpStatus.GONE);
+            DefaultFallbackApiExceptionHandler handler = createDefaultFallbackApiExceptionHandler(properties);
+            MyEntityNotFoundException exception = new MyEntityNotFoundException();
+            ApiErrorResponse response = handler.handle(exception);
+            assertThat(response.getHttpStatus()).isEqualTo(HttpStatus.GONE);
+        }
+
+        @Test
+        void propertiesConfigurationInSuperClassIfSearchDisabled() {
+            ErrorHandlingProperties properties = new ErrorHandlingProperties();
+            properties.setSearchSuperClassHierarchy(false);
+            properties.getHttpStatuses().put(RuntimeException.class.getName(), HttpStatus.ALREADY_REPORTED);
+            DefaultFallbackApiExceptionHandler handler = createDefaultFallbackApiExceptionHandler(properties);
+            MyEntityNotFoundException exception = new MyEntityNotFoundException();
+            ApiErrorResponse response = handler.handle(exception);
+            assertThat(response.getHttpStatus()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+
     }
 
     @Nested
@@ -109,6 +132,28 @@ class DefaultFallbackApiExceptionHandlerTest {
             ApiErrorResponse response = handler.handle(exception);
             assertThat(response.getCode()).isEqualTo("CODE_VIA_PROPERTIES");
         }
+
+        @Test
+        void propertiesConfigurationInSuperClass() {
+            ErrorHandlingProperties properties = new ErrorHandlingProperties();
+            properties.setSearchSuperClassHierarchy(true);
+            properties.getCodes().put(RuntimeException.class.getName(), "RUNTIME");
+            DefaultFallbackApiExceptionHandler handler = createDefaultFallbackApiExceptionHandler(properties);
+            MyEntityNotFoundException exception = new MyEntityNotFoundException();
+            ApiErrorResponse response = handler.handle(exception);
+            assertThat(response.getCode()).isEqualTo("RUNTIME");
+        }
+
+        @Test
+        void propertiesConfigurationInSuperClassIfSearchDisabled() {
+            ErrorHandlingProperties properties = new ErrorHandlingProperties();
+            properties.setSearchSuperClassHierarchy(false);
+            properties.getCodes().put(RuntimeException.class.getName(), "RUNTIME");
+            DefaultFallbackApiExceptionHandler handler = createDefaultFallbackApiExceptionHandler(properties);
+            MyEntityNotFoundException exception = new MyEntityNotFoundException();
+            ApiErrorResponse response = handler.handle(exception);
+            assertThat(response.getCode()).isEqualTo("MY_ENTITY_NOT_FOUND");
+        }
     }
 
     @Nested
@@ -129,6 +174,28 @@ class DefaultFallbackApiExceptionHandlerTest {
             properties.getMessages().put(exception.getClass().getName(), "This is the exception message via properties");
             ApiErrorResponse response = handler.handle(exception);
             assertThat(response.getMessage()).isEqualTo("This is the exception message via properties");
+        }
+
+        @Test
+        void propertiesConfigurationInSuperClass() {
+            ErrorHandlingProperties properties = new ErrorHandlingProperties();
+            properties.setSearchSuperClassHierarchy(true);
+            properties.getMessages().put(RuntimeException.class.getName(), "A runtime exception happened");
+            DefaultFallbackApiExceptionHandler handler = createDefaultFallbackApiExceptionHandler(properties);
+            MyEntityNotFoundException exception = new MyEntityNotFoundException();
+            ApiErrorResponse response = handler.handle(exception);
+            assertThat(response.getMessage()).isEqualTo("A runtime exception happened");
+        }
+
+        @Test
+        void propertiesConfigurationInSuperClassIfSearchDisabled() {
+            ErrorHandlingProperties properties = new ErrorHandlingProperties();
+            properties.setSearchSuperClassHierarchy(false);
+            properties.getMessages().put(RuntimeException.class.getName(), "A runtime exception happened");
+            DefaultFallbackApiExceptionHandler handler = createDefaultFallbackApiExceptionHandler(properties);
+            MyEntityNotFoundException exception = new MyEntityNotFoundException();
+            ApiErrorResponse response = handler.handle(exception);
+            assertThat(response.getMessage()).isNull();
         }
     }
 


### PR DESCRIPTION
This allows to define an override for the `ErrorCode`, `HttpStatus` and `Message` for any **Exception** class in a class hierarchy.

For example, you could have some exceptions like `com.acme.EntiyOneNotFoundException` and `com.acme.EntityTwoNotFoundExtension` both of them extending `com.acme.NotFoundException`.

Now you can set the same `HttpStatus` for any child of `com.acme.NotFoundException` by specifying:

`error.handling.http-statuses.com.acme.NotFoundException=not_found`

If there is a new `com.acme.EntityThreeNotFoundException` it also "inherits" it's "ancestor" `HttpStatus`, but you could set:

`error.handling.http-statuses.com.acme.EntityThreeNotFoundException=bad_request`

and that would take precedence over it's parent settings.