### PR TITLE
Allow reset to using the message of the exception itself in the exception class hierarchy

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -586,12 +586,33 @@ Then the response will be:
 }
 ----
 
-If you which to restore default error messaging from a certain point in the class hierarchy (say `MyException`), you can reset it using
+==== Reset back to default messaging at a point in exception class hierarchy
+
+Consider that case where you have an exception like:
+
+[source,java]
+----
+public class ApplicationException extends RuntimeException {}
+----
+
+but you already have the following configuration:
 
 [source,properties]
 ----
-error.handling.messages.com.example.MyException=
+error.handling.messages.java.lang.RuntimeException=A runtime exception has happened
+error.handling.search-super-class-hierarchy=true
 ----
+
+You may reset back to default error messaging from a certain point in the class hierarchy (say
+`my.ApplicationException`) by providing an empty value for that exception.
+
+[source,properties]
+----
+error.handling.messages.my.ApplicationException=
+----
+
+Now, `ApplicationException` and its subclasses will fall back to default messaging behaviour, rather than always showing
+"A runtime exception has happened".
 
 === Exception handlers
 

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -586,6 +586,13 @@ Then the response will be:
 }
 ----
 
+If you which to restore default error messaging from a certain point in the class hierarchy (say `MyException`), you can reset it using
+
+[source,properties]
+----
+error.handling.messages.com.example.MyException=
+----
+
 === Exception handlers
 
 ==== Validation

--- a/src/main/java/io/github/wimdeblauwe/errorhandlingspringbootstarter/mapper/ErrorMessageMapper.java
+++ b/src/main/java/io/github/wimdeblauwe/errorhandlingspringbootstarter/mapper/ErrorMessageMapper.java
@@ -2,6 +2,8 @@ package io.github.wimdeblauwe.errorhandlingspringbootstarter.mapper;
 
 import io.github.wimdeblauwe.errorhandlingspringbootstarter.ErrorHandlingProperties;
 
+import static org.springframework.util.StringUtils.hasText;
+
 /**
  * This class contains the logic for getting the matching error message for the given {@link Throwable}.
  */
@@ -14,7 +16,7 @@ public class ErrorMessageMapper {
 
     public String getErrorMessage(Throwable exception) {
         String code = getErrorMessageFromProperties(exception.getClass());
-        if (code != null) {
+        if (hasText(code)) {
             return code;
         }
         return exception.getMessage();

--- a/src/test/java/io/github/wimdeblauwe/errorhandlingspringbootstarter/DefaultFallbackApiExceptionHandlerTest.java
+++ b/src/test/java/io/github/wimdeblauwe/errorhandlingspringbootstarter/DefaultFallbackApiExceptionHandlerTest.java
@@ -188,6 +188,27 @@ class DefaultFallbackApiExceptionHandlerTest {
         }
 
         @Test
+        void propertiesConfigurationInSuperClassWithHierarchyReset() {
+            ErrorHandlingProperties properties = new ErrorHandlingProperties();
+            properties.setSearchSuperClassHierarchy(true);
+            properties.getMessages().put(RuntimeException.class.getName(), "A runtime exception happened");
+            properties.getMessages().put(ApplicationException.class.getName(), null);
+            DefaultFallbackApiExceptionHandler handler = createDefaultFallbackApiExceptionHandler(properties);
+            // class at hierarchy reset point
+            ApplicationException applicationException = new ApplicationException("Application exception message");
+            ApiErrorResponse applicationExceptionResponse = handler.handle(applicationException);
+            assertThat(applicationExceptionResponse.getMessage()).isEqualTo("Application exception message");
+            // subclass within reset hierarchy
+            SubclassOfApplicationException subclassOfApplicationException = new SubclassOfApplicationException("Subclass of application exception message");
+            ApiErrorResponse subclassOfApplicationExceptionResponse = handler.handle(subclassOfApplicationException);
+            assertThat(subclassOfApplicationExceptionResponse.getMessage()).isEqualTo("Subclass of application exception message");
+            // class outside reset hierarchy
+            MyEntityNotFoundException exception = new MyEntityNotFoundException();
+            ApiErrorResponse response = handler.handle(exception);
+            assertThat(response.getMessage()).isEqualTo("A runtime exception happened");
+        }
+
+        @Test
         void propertiesConfigurationInSuperClassIfSearchDisabled() {
             ErrorHandlingProperties properties = new ErrorHandlingProperties();
             properties.setSearchSuperClassHierarchy(false);

--- a/src/test/java/io/github/wimdeblauwe/errorhandlingspringbootstarter/exception/ApplicationException.java
+++ b/src/test/java/io/github/wimdeblauwe/errorhandlingspringbootstarter/exception/ApplicationException.java
@@ -1,0 +1,9 @@
+package io.github.wimdeblauwe.errorhandlingspringbootstarter.exception;
+
+public class ApplicationException extends RuntimeException {
+
+    public ApplicationException(String message) {
+        super(message);
+    }
+
+}

--- a/src/test/java/io/github/wimdeblauwe/errorhandlingspringbootstarter/exception/SubclassOfApplicationException.java
+++ b/src/test/java/io/github/wimdeblauwe/errorhandlingspringbootstarter/exception/SubclassOfApplicationException.java
@@ -1,0 +1,9 @@
+package io.github.wimdeblauwe.errorhandlingspringbootstarter.exception;
+
+public class SubclassOfApplicationException extends ApplicationException {
+
+    public SubclassOfApplicationException(String message) {
+        super(message);
+    }
+    
+}


### PR DESCRIPTION
Allow a more specific super class to "reset" the override of error message from a higher superclass by providing an empty message. This allows it (and its subclasses) to use the default message handling again.

Currently, if one sets `error.handling.messages.java.lang.RuntimeException=A runtime exception has happened` with `error.handling.search-super-class-hierarchy=true`, there's no way (that I know of) to let any application exception to provide fall back to default messaging again. This allows, say `ApplicationException` (that extends from `RuntimeException`) and all those that extend `ApplicationException` to have their messages returned using default fallback capabilities by providing an empty value for `error.handling.messages.com.example.ApplicationException=`

I don't always want the custom message from the general `RuntimeException` to be returned from the API but I do want custom application exception messages to be returned (that extend `RuntimeException`)

Perhaps, there's a better way, in which case this can just serve as an issue for further discussion.

Thanks,
Stephen