### PR TITLE
Added support for reactive web and Spring WebFlux

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,7 @@ jobs:
             ${{ runner.os }}-maven-
 
       - name: Build with Maven
-        run: ./mvnw clean verify
+        run: ./mvnw -B clean verify
 
       - name: GitHub Pages action
         if: |

--- a/pom.xml
+++ b/pom.xml
@@ -91,6 +91,11 @@
             <artifactId>spring-orm</artifactId>
             <optional>true</optional>
         </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-webflux</artifactId>
+            <optional>true</optional>
+        </dependency>
 
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/src/main/java/io/github/wimdeblauwe/errorhandlingspringbootstarter/ErrorHandlingControllerAdvice.java
+++ b/src/main/java/io/github/wimdeblauwe/errorhandlingspringbootstarter/ErrorHandlingControllerAdvice.java
@@ -2,6 +2,7 @@ package io.github.wimdeblauwe.errorhandlingspringbootstarter;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
 import org.springframework.core.annotation.AnnotationAwareOrderComparator;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -14,6 +15,7 @@ import java.util.List;
 import java.util.Locale;
 
 @ControllerAdvice(annotations = RestController.class)
+@ConditionalOnWebApplication(type = ConditionalOnWebApplication.Type.SERVLET)
 public class ErrorHandlingControllerAdvice {
     private static final Logger LOGGER = LoggerFactory.getLogger(ErrorHandlingControllerAdvice.class);
 

--- a/src/main/java/io/github/wimdeblauwe/errorhandlingspringbootstarter/GlobalErrorWebExceptionHandler.java
+++ b/src/main/java/io/github/wimdeblauwe/errorhandlingspringbootstarter/GlobalErrorWebExceptionHandler.java
@@ -97,11 +97,11 @@ public class GlobalErrorWebExceptionHandler extends DefaultErrorWebExceptionHand
         }
         List<ApiParameterError> parameterErrors = errorResponse.getParameterErrors();
         if(!parameterErrors.isEmpty()) {
-            mapResponse.put("paramaterErrors", parameterErrors);
+            mapResponse.put("parameterErrors", parameterErrors);
         }
         Map<String, Object> properties = errorResponse.getProperties();
         if(!properties.isEmpty()) {
-            mapResponse.put("propertes", properties);
+            mapResponse.put("properties", properties);
         }
         logException(errorResponse, exception);
         return ServerResponse.status(errorResponse.getHttpStatus())

--- a/src/main/java/io/github/wimdeblauwe/errorhandlingspringbootstarter/GlobalErrorWebExceptionHandler.java
+++ b/src/main/java/io/github/wimdeblauwe/errorhandlingspringbootstarter/GlobalErrorWebExceptionHandler.java
@@ -1,0 +1,152 @@
+package io.github.wimdeblauwe.errorhandlingspringbootstarter;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.web.ErrorProperties;
+import org.springframework.boot.autoconfigure.web.WebProperties;
+import org.springframework.boot.autoconfigure.web.reactive.error.DefaultErrorWebExceptionHandler;
+import org.springframework.boot.web.reactive.error.ErrorAttributes;
+import org.springframework.context.ApplicationContext;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.web.reactive.function.BodyInserters;
+import org.springframework.web.reactive.function.server.*;
+import reactor.core.publisher.Mono;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+public class GlobalErrorWebExceptionHandler extends DefaultErrorWebExceptionHandler {
+    private static final Logger LOGGER = LoggerFactory.getLogger(GlobalErrorWebExceptionHandler.class);
+
+    private final ErrorHandlingProperties properties;
+    private final List<ApiExceptionHandler> handlers;
+    private final FallbackApiExceptionHandler fallbackHandler;
+
+    /**
+     * Create a new {@code DefaultErrorWebExceptionHandler} instance.
+     *
+     * @param errorAttributes    the error attributes
+     * @param resources          the resources configuration properties
+     * @param errorProperties    the error configuration properties
+     * @param applicationContext the current application context
+     * @param properties
+     * @param handlers
+     * @param fallbackHandler
+     * @since 2.4.0
+     */
+    public GlobalErrorWebExceptionHandler(ErrorAttributes errorAttributes,
+                                          WebProperties.Resources resources,
+                                          ErrorProperties errorProperties,
+                                          ApplicationContext applicationContext,
+                                          ErrorHandlingProperties properties,
+                                          List<ApiExceptionHandler> handlers,
+                                          FallbackApiExceptionHandler fallbackHandler
+    ) {
+        super(errorAttributes, resources, errorProperties, applicationContext);
+        this.properties = properties;
+        this.handlers = handlers;
+        this.fallbackHandler = fallbackHandler;
+    }
+
+    // constructors
+
+    @Override
+    protected RouterFunction<ServerResponse> getRoutingFunction(ErrorAttributes errorAttributes) {
+        return RouterFunctions.route(RequestPredicates.all(), this::renderErrorResponse);
+    }
+
+    @Override
+    protected Mono<ServerResponse> renderErrorResponse(ServerRequest request) {
+//        Map<String, Object> errorPropertiesMap = getErrorAttributes(request, ErrorAttributeOptions.defaults());
+//        Map<String, Object> errorPropertiesMap = handleException(request);
+//        return ServerResponse.status(HttpStatus.BAD_REQUEST).contentType(MediaType.APPLICATION_JSON).body(BodyInserters.fromValue(errorPropertiesMap));
+        return handleException(request);
+    }
+
+    public Mono<ServerResponse> handleException(ServerRequest request) {
+        Locale locale = request.exchange().getLocaleContext().getLocale();
+        Throwable exception = getError(request);
+        LOGGER.debug("webRequest: {}", request);
+        LOGGER.debug("locale: {}", locale);
+
+        ApiErrorResponse errorResponse = null;
+        for (ApiExceptionHandler handler : handlers) {
+            if (handler.canHandle(exception)) {
+                errorResponse = handler.handle(exception);
+                break;
+            }
+        }
+
+        if (errorResponse == null) {
+            errorResponse = fallbackHandler.handle(exception);
+        }
+
+        Map<String, Object> mapResponse = new HashMap<>();
+        mapResponse.put("code", errorResponse.getCode());
+        mapResponse.put("message", errorResponse.getMessage());
+        List<ApiGlobalError> globalErrors = errorResponse.getGlobalErrors();
+        if(!globalErrors.isEmpty()) {
+            mapResponse.put("globalErrors", globalErrors);
+        }
+        List<ApiFieldError> fieldErrors = errorResponse.getFieldErrors();
+        if(!fieldErrors.isEmpty()) {
+            mapResponse.put("fieldErrors", fieldErrors);
+        }
+        List<ApiParameterError> parameterErrors = errorResponse.getParameterErrors();
+        if(!parameterErrors.isEmpty()) {
+            mapResponse.put("paramaterErrors", parameterErrors);
+        }
+        Map<String, Object> properties = errorResponse.getProperties();
+        if(!properties.isEmpty()) {
+            mapResponse.put("propertes", properties);
+        }
+        logException(errorResponse, exception);
+        return ServerResponse.status(errorResponse.getHttpStatus())
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(BodyInserters.fromValue(mapResponse));
+    }
+
+    private void logException(ApiErrorResponse errorResponse, Throwable exception) {
+        if (properties.getFullStacktraceClasses().contains(exception.getClass())) {
+            LOGGER.error(exception.getMessage(), exception);
+        } else if (!properties.getFullStacktraceHttpStatuses().isEmpty()) {
+            boolean alreadyLogged = logFullStacktraceIfNeeded(errorResponse.getHttpStatus(), exception);
+            if (!alreadyLogged) {
+                doStandardFallbackLogging(exception);
+            }
+        } else {
+            doStandardFallbackLogging(exception);
+        }
+    }
+
+    private void doStandardFallbackLogging(Throwable exception) {
+        switch (properties.getExceptionLogging()) {
+            case WITH_STACKTRACE:
+                LOGGER.error(exception.getMessage(), exception);
+                break;
+            case MESSAGE_ONLY:
+                LOGGER.error(exception.getMessage());
+                break;
+        }
+    }
+
+    private boolean logFullStacktraceIfNeeded(HttpStatus httpStatus, Throwable exception) {
+        String httpStatusValue = String.valueOf(httpStatus.value());
+        if (properties.getFullStacktraceHttpStatuses().contains(httpStatusValue)) {
+            LOGGER.error(exception.getMessage(), exception);
+            return true;
+        } else if (properties.getFullStacktraceHttpStatuses().contains(httpStatusValue.replaceFirst("\\d$", "x"))) {
+            LOGGER.error(exception.getMessage(), exception);
+            return true;
+        } else if (properties.getFullStacktraceHttpStatuses().contains(httpStatusValue.replaceFirst("\\d\\d$", "xx"))) {
+            LOGGER.error(exception.getMessage(), exception);
+            return true;
+        }
+
+        return false;
+    }
+
+}

--- a/src/main/java/io/github/wimdeblauwe/errorhandlingspringbootstarter/ReactiveErrorHandlingConfiguration.java
+++ b/src/main/java/io/github/wimdeblauwe/errorhandlingspringbootstarter/ReactiveErrorHandlingConfiguration.java
@@ -1,0 +1,140 @@
+package io.github.wimdeblauwe.errorhandlingspringbootstarter;
+
+import io.github.wimdeblauwe.errorhandlingspringbootstarter.handler.*;
+import io.github.wimdeblauwe.errorhandlingspringbootstarter.mapper.ErrorCodeMapper;
+import io.github.wimdeblauwe.errorhandlingspringbootstarter.mapper.ErrorMessageMapper;
+import io.github.wimdeblauwe.errorhandlingspringbootstarter.mapper.HttpStatusMapper;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.boot.autoconfigure.condition.*;
+import org.springframework.boot.autoconfigure.web.ServerProperties;
+import org.springframework.boot.autoconfigure.web.WebProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.web.reactive.error.DefaultErrorAttributes;
+import org.springframework.boot.web.reactive.error.ErrorAttributes;
+import org.springframework.boot.web.reactive.error.ErrorWebExceptionHandler;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.PropertySource;
+import org.springframework.core.annotation.Order;
+import org.springframework.http.codec.ServerCodecConfigurer;
+import org.springframework.web.reactive.result.view.ViewResolver;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Configuration
+@ConditionalOnWebApplication(type = ConditionalOnWebApplication.Type.REACTIVE)
+@EnableConfigurationProperties({ErrorHandlingProperties.class, WebProperties.class, ServerProperties.class})
+@ConditionalOnProperty(value = "error.handling.enabled", matchIfMissing = true)
+@PropertySource("classpath:/error-handling-defaults.properties")
+public class ReactiveErrorHandlingConfiguration {
+
+    @Bean
+    @Order(-2)
+    public ErrorWebExceptionHandler globalErrorWebExceptionHandler(ErrorAttributes errorAttributes, ServerProperties serverProperties,
+                                                             WebProperties webProperties, ObjectProvider<ViewResolver> viewResolvers,
+                                                             ServerCodecConfigurer serverCodecConfigurer, ApplicationContext applicationContext,
+                                                                   ErrorHandlingProperties properties,
+                                                                   List<ApiExceptionHandler> handlers,
+                                                                   FallbackApiExceptionHandler fallbackApiExceptionHandler) {
+
+        GlobalErrorWebExceptionHandler exceptionHandler = new GlobalErrorWebExceptionHandler(errorAttributes,
+                                                                                             webProperties.getResources(),
+                                                                                             serverProperties.getError(),
+                                                                                             applicationContext,
+                                                                                             properties,
+                                                                                             handlers,
+                                                                                             fallbackApiExceptionHandler
+        );
+        exceptionHandler.setViewResolvers(viewResolvers.orderedStream().collect(Collectors.toList()));
+        exceptionHandler.setMessageWriters(serverCodecConfigurer.getWriters());
+        exceptionHandler.setMessageReaders(serverCodecConfigurer.getReaders());
+        return exceptionHandler;
+    }
+
+    @Bean
+    public HttpStatusMapper httpStatusMapper(ErrorHandlingProperties properties) {
+        return new HttpStatusMapper(properties);
+    }
+
+    @Bean
+    public ErrorCodeMapper errorCodeMapper(ErrorHandlingProperties properties) {
+        return new ErrorCodeMapper(properties);
+    }
+
+    @Bean
+    public ErrorMessageMapper errorMessageMapper(ErrorHandlingProperties properties) {
+        return new ErrorMessageMapper(properties);
+    }
+
+    @Bean
+    public FallbackApiExceptionHandler defaultHandler(HttpStatusMapper httpStatusMapper,
+                                                      ErrorCodeMapper errorCodeMapper,
+                                                      ErrorMessageMapper errorMessageMapper) {
+        return new DefaultFallbackApiExceptionHandler(httpStatusMapper,
+                                                      errorCodeMapper,
+                                                      errorMessageMapper);
+    }
+
+    @Bean
+    public TypeMismatchApiExceptionHandler typeMismatchApiExceptionHandler(ErrorHandlingProperties properties,
+                                                                           HttpStatusMapper httpStatusMapper,
+                                                                           ErrorCodeMapper errorCodeMapper,
+                                                                           ErrorMessageMapper errorMessageMapper) {
+        return new TypeMismatchApiExceptionHandler(properties, httpStatusMapper, errorCodeMapper, errorMessageMapper);
+    }
+
+    @Bean
+    public ConstraintViolationApiExceptionHandler constraintViolationApiExceptionHandler(ErrorHandlingProperties properties,
+                                                                                         HttpStatusMapper httpStatusMapper,
+                                                                                         ErrorCodeMapper errorCodeMapper,
+                                                                                         ErrorMessageMapper errorMessageMapper) {
+        return new ConstraintViolationApiExceptionHandler(properties, httpStatusMapper, errorCodeMapper, errorMessageMapper);
+    }
+
+    @Bean
+    public HttpMessageNotReadableApiExceptionHandler httpMessageNotReadableApiExceptionHandler(ErrorHandlingProperties properties,
+                                                                                               HttpStatusMapper httpStatusMapper,
+                                                                                               ErrorCodeMapper errorCodeMapper,
+                                                                                               ErrorMessageMapper errorMessageMapper) {
+        return new HttpMessageNotReadableApiExceptionHandler(properties, httpStatusMapper, errorCodeMapper, errorMessageMapper);
+    }
+
+    @Bean
+    public BindApiExceptionHandler bindApiExceptionHandler(ErrorHandlingProperties properties,
+                                                           HttpStatusMapper httpStatusMapper,
+                                                           ErrorCodeMapper errorCodeMapper,
+                                                           ErrorMessageMapper errorMessageMapper) {
+        return new BindApiExceptionHandler(properties, httpStatusMapper, errorCodeMapper, errorMessageMapper);
+    }
+
+    @Bean
+    @ConditionalOnClass(name = "org.springframework.security.access.AccessDeniedException")
+    public SpringSecurityApiExceptionHandler springSecurityApiExceptionHandler(ErrorHandlingProperties properties,
+                                                                               HttpStatusMapper httpStatusMapper,
+                                                                               ErrorCodeMapper errorCodeMapper,
+                                                                               ErrorMessageMapper errorMessageMapper) {
+        return new SpringSecurityApiExceptionHandler(properties, httpStatusMapper, errorCodeMapper, errorMessageMapper);
+    }
+
+    @Bean
+    @ConditionalOnClass(name = "org.springframework.orm.ObjectOptimisticLockingFailureException")
+    public ObjectOptimisticLockingFailureApiExceptionHandler objectOptimisticLockingFailureApiExceptionHandler(ErrorHandlingProperties properties,
+                                                                                                               HttpStatusMapper httpStatusMapper,
+                                                                                                               ErrorCodeMapper errorCodeMapper,
+                                                                                                               ErrorMessageMapper errorMessageMapper) {
+        return new ObjectOptimisticLockingFailureApiExceptionHandler(properties, httpStatusMapper, errorCodeMapper, errorMessageMapper);
+    }
+
+    @Bean
+    public ApiErrorResponseSerializer apiErrorResponseSerializer(ErrorHandlingProperties properties) {
+        return new ApiErrorResponseSerializer(properties);
+    }
+
+    @Bean
+    @ConditionalOnMissingBean(value = ErrorAttributes.class, search = SearchStrategy.CURRENT)
+    public DefaultErrorAttributes errorAttributes() {
+        return new DefaultErrorAttributes();
+    }
+}

--- a/src/main/resources/META-INF/spring.factories
+++ b/src/main/resources/META-INF/spring.factories
@@ -1,4 +1,4 @@
 org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
-  io.github.wimdeblauwe.errorhandlingspringbootstarter.ErrorHandlingConfiguration
+  io.github.wimdeblauwe.errorhandlingspringbootstarter.ErrorHandlingConfiguration,io.github.wimdeblauwe.errorhandlingspringbootstarter.ReactiveErrorHandlingConfiguration
 org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc=\
   io.github.wimdeblauwe.errorhandlingspringbootstarter.ErrorHandlingConfiguration

--- a/src/test/java/io/github/wimdeblauwe/errorhandlingspringbootstarter/ReactiveIntegrationTest.java
+++ b/src/test/java/io/github/wimdeblauwe/errorhandlingspringbootstarter/ReactiveIntegrationTest.java
@@ -1,0 +1,69 @@
+package io.github.wimdeblauwe.errorhandlingspringbootstarter;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.test.autoconfigure.web.reactive.WebFluxTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.codec.ServerCodecConfigurer;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.reactive.server.WebTestClient;
+
+@WebFluxTest(
+        properties = {
+                "spring.main.web-application-type=reactive",
+                "spring.main.allow-bean-definition-overriding=true",
+                "error.handling.full-stacktrace-http-statuses[0]=500"
+        },
+        controllers = ReactiveIntegrationTestRestController.class
+)
+@ImportAutoConfiguration(classes = {ReactiveErrorHandlingConfiguration.class, ReactiveIntegrationTest.CodecConfig.class,})
+public class ReactiveIntegrationTest {
+
+    @Autowired
+    WebTestClient webTestClient;
+
+    @Test
+    @WithMockUser
+    void testRuntimeException() throws Exception {
+        webTestClient.get()
+                     .uri("/integration-test/runtime")
+                     .accept(MediaType.ALL)
+                     .exchange()
+                     .expectStatus().isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+
+    @Test
+    @WithMockUser
+    void testExceptionWithBadRequestStatus() throws Exception {
+        webTestClient.get()
+                     .uri("/integration-test/bad-request")
+                     .exchange()
+                     .expectStatus().isBadRequest();
+    }
+
+    @Test
+    @WithMockUser
+    void testApplicationException() throws Exception {
+        webTestClient.get()
+                     .uri("/integration-test/application-request")
+                     .exchange()
+                     .expectStatus().is5xxServerError()
+                     .expectBody()
+                        .jsonPath("$.code").isEqualTo("APPLICATION")
+                        .jsonPath("$.message").isEqualTo("Application error");
+    }
+
+    static class CodecConfig {
+
+        @Bean
+        @ConditionalOnMissingBean(ServerCodecConfigurer.class)
+        public ServerCodecConfigurer serverCodecConfigurer() {
+            return ServerCodecConfigurer.create();
+        }
+    }
+
+}

--- a/src/test/java/io/github/wimdeblauwe/errorhandlingspringbootstarter/ReactiveIntegrationTestRestController.java
+++ b/src/test/java/io/github/wimdeblauwe/errorhandlingspringbootstarter/ReactiveIntegrationTestRestController.java
@@ -1,0 +1,29 @@
+package io.github.wimdeblauwe.errorhandlingspringbootstarter;
+
+import io.github.wimdeblauwe.errorhandlingspringbootstarter.exception.ApplicationException;
+import io.github.wimdeblauwe.errorhandlingspringbootstarter.exception.ExceptionWithBadRequestStatus;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.function.ServerResponse;
+import reactor.core.publisher.Mono;
+
+@RestController
+@RequestMapping("/integration-test")
+public class ReactiveIntegrationTestRestController {
+
+    @GetMapping("/runtime")
+    Mono<Void> throwRuntimeException() {
+        throw new RuntimeException("This is a test RuntimeException");
+    }
+
+    @GetMapping("/bad-request")
+    Mono<String> throwExceptionWithBadRequestStatus() {
+        throw new ExceptionWithBadRequestStatus();
+    }
+
+    @GetMapping("/application-request")
+    Mono<String> throwApplicationException() {
+        throw new ApplicationException("Application error");
+    }
+}


### PR DESCRIPTION
Added a new `ReactiveErrorHandlingConfiguration` that uses a `GlobalErrorWebExceptionHandler` to bring the compatibility with Project Reactor and Spring web flux applications.

To enable support in reactive application just import the configuration with
````java
@ImportAutoConfiguration({ReactiveErrorHandlingConfiguration.class})
````
on top of a `@Configuration` class in your Spring Boot project