### PR TITLE
feat: Support ProblemDetail

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -1459,6 +1459,173 @@ Those are implementations of `jakarta.servlet.Filter`, usually subclasses of `or
 
 By setting the property `error.handling.handle-filter-chain-exceptions` to `true`, the library will handle those exceptions and return error responses just like is done for exceptions coming from controller methods.
 
+=== Problem Detail format (RFC 9457)
+
+The library supports the https://www.rfc-editor.org/rfc/rfc9457[RFC 9457] Problem Detail format as an alternative to the default JSON response format.
+When enabled, error responses will use the standardized Problem Detail structure and the `application/problem+json` content type.
+
+==== Enabling Problem Detail format
+
+To enable Problem Detail format, set the following property:
+
+[source,properties]
+----
+error.handling.use-problem-detail-format=true
+----
+
+==== Response format comparison
+
+When Problem Detail format is disabled (default), the response looks like this:
+
+[source,json]
+----
+{
+  "code": "USER_NOT_FOUND",
+  "message": "Could not find user with id 123"
+}
+----
+
+When Problem Detail format is enabled, the same error produces:
+
+[source,json]
+----
+{
+  "type": "user-not-found",
+  "title": "Not Found",
+  "status": 404,
+  "detail": "Could not find user with id 123"
+}
+----
+
+The Problem Detail format is built like this:
+
+[cols="1,1"]
+|===
+|Problem Detail field | Description
+
+|`type`
+|Value of the `code` field (converted to kebab-case by default)
+
+|`detail`
+|Value of the `message` field
+
+|`title`
+|The HTTP status text (This is coming from Spring itself)
+
+|`status`
+|The numeric HTTP status code
+|===
+
+==== Configuring the type prefix
+
+You can add a prefix to the `type` field to create fully qualified URIs.
+This is useful for providing documentation links for your error types:
+
+[source,properties]
+----
+error.handling.use-problem-detail-format=true
+error.handling.problem-detail-type-prefix=https://api.example.com/errors/
+----
+
+With this configuration, the response becomes:
+
+[source,json]
+----
+{
+  "type": "https://api.example.com/errors/user-not-found",
+  "title": "Not Found",
+  "status": 404,
+  "detail": "Could not find user with id 123"
+}
+----
+
+==== Disabling kebab-case conversion
+
+By default, error codes are converted to kebab-case for the `type` field (e.g., `USER_NOT_FOUND` becomes `user-not-found`).
+To preserve the original error code format, disable the conversion:
+
+[source,properties]
+----
+error.handling.use-problem-detail-format=true
+error.handling.problem-detail-convert-to-kebab-case=false
+----
+
+Result:
+
+[source,json]
+----
+{
+  "type": "USER_NOT_FOUND",
+  "title": "Not Found",
+  "status": 404,
+  "detail": "Could not find user with id 123"
+}
+----
+
+==== Validation errors with Problem Detail
+
+Validation errors include `fieldErrors` and `globalErrors` as additional properties in the Problem Detail response:
+
+[source,json]
+----
+{
+  "type": "validation-failed",
+  "title": "Bad Request",
+  "status": 400,
+  "detail": "Validation failed for object='exampleRequestBody'. Error count: 2",
+  "fieldErrors": [
+    {
+      "code": "INVALID_SIZE",
+      "property": "name",
+      "message": "size must be between 10 and 2147483647",
+      "rejectedValue": "",
+      "path": "name"
+    },
+    {
+      "code": "REQUIRED_NOT_BLANK",
+      "property": "favoriteMovie",
+      "message": "must not be blank",
+      "rejectedValue": null,
+      "path": "favoriteMovie"
+    }
+  ]
+}
+----
+
+==== Custom properties with Problem Detail
+
+Custom properties added via `@ResponseErrorProperty` are included in the Problem Detail response:
+
+[source,java]
+----
+@ResponseStatus(HttpStatus.CONFLICT)
+@ResponseErrorCode("OPTIMISTIC_LOCKING_ERROR")
+public class OptimisticLockingException extends RuntimeException {
+
+    @ResponseErrorProperty
+    private final String identifier;
+
+    @ResponseErrorProperty
+    private final String persistentClassName;
+
+    // constructor and getters
+}
+----
+
+With the type prefix configured, the response would be:
+
+[source,json]
+----
+{
+  "type": "https://api.example.com/errors/optimistic-locking-error",
+  "title": "Conflict",
+  "status": 409,
+  "detail": "Object of class [com.example.user.User] with identifier [1]: optimistic locking failed",
+  "identifier": "1",
+  "persistentClassName": "com.example.user.User"
+}
+----
+
 == Custom exception handler
 
 If the <<Configuration,extensive customization options>> are not enough, you can write your own `ApiExceptionHandler` implementation.
@@ -1585,7 +1752,19 @@ When this is set to `true`, you can use any superclass from your `Exception` typ
 
 |error.handling.handle-filter-chain-exceptions
 |Set this to `true` to have the library intercept any exception thrown from custom filters and also have the same error responses as exceptions thrown from controller methods.
-|`false`.
+|`false`
+
+|error.handling.use-problem-detail-format
+|Set this to `true` to use the https://www.rfc-editor.org/rfc/rfc9457[RFC 9457] Problem Detail format for error responses instead of the default format.
+|`false`
+
+|error.handling.problem-detail-type-prefix
+|The prefix to use for the `type` field in Problem Detail responses. This is typically a URL that serves as a namespace for the error types.
+|Empty string
+
+|error.handling.problem-detail-convert-to-kebab-case
+|When using Problem Detail format, this controls whether the error code is converted to kebab-case for the `type` field. For example, `USER_NOT_FOUND` would become `user-not-found`.
+|`true`
 |===
 
 == Adding Error Responses to OpenAPI Documentation

--- a/src/main/java/io/github/wimdeblauwe/errorhandlingspringbootstarter/ErrorHandlingProperties.java
+++ b/src/main/java/io/github/wimdeblauwe/errorhandlingspringbootstarter/ErrorHandlingProperties.java
@@ -45,6 +45,8 @@ public class ErrorHandlingProperties {
 
     private String problemDetailTypePrefix = "";
 
+    private boolean problemDetailConvertToKebabCase = true;
+
     public boolean isEnabled() {
         return enabled;
     }
@@ -171,6 +173,14 @@ public class ErrorHandlingProperties {
 
     public void setProblemDetailTypePrefix(String problemDetailTypePrefix) {
         this.problemDetailTypePrefix = problemDetailTypePrefix;
+    }
+
+    public boolean isProblemDetailConvertToKebabCase() {
+        return problemDetailConvertToKebabCase;
+    }
+
+    public void setProblemDetailConvertToKebabCase(boolean problemDetailConvertToKebabCase) {
+        this.problemDetailConvertToKebabCase = problemDetailConvertToKebabCase;
     }
 
     public enum ExceptionLogging {

--- a/src/main/java/io/github/wimdeblauwe/errorhandlingspringbootstarter/ErrorHandlingProperties.java
+++ b/src/main/java/io/github/wimdeblauwe/errorhandlingspringbootstarter/ErrorHandlingProperties.java
@@ -41,6 +41,10 @@ public class ErrorHandlingProperties {
 
     private boolean handleFilterChainExceptions = false;
 
+    private boolean useProblemDetailFormat = false;
+
+    private String problemDetailTypePrefix = "";
+
     public boolean isEnabled() {
         return enabled;
     }
@@ -151,6 +155,22 @@ public class ErrorHandlingProperties {
 
     public void setHandleFilterChainExceptions(boolean handleFilterChainExceptions) {
         this.handleFilterChainExceptions = handleFilterChainExceptions;
+    }
+
+    public boolean isUseProblemDetailFormat() {
+        return useProblemDetailFormat;
+    }
+
+    public void setUseProblemDetailFormat(boolean useProblemDetailFormat) {
+        this.useProblemDetailFormat = useProblemDetailFormat;
+    }
+
+    public String getProblemDetailTypePrefix() {
+        return problemDetailTypePrefix;
+    }
+
+    public void setProblemDetailTypePrefix(String problemDetailTypePrefix) {
+        this.problemDetailTypePrefix = problemDetailTypePrefix;
     }
 
     public enum ExceptionLogging {

--- a/src/main/java/io/github/wimdeblauwe/errorhandlingspringbootstarter/ProblemDetailFactory.java
+++ b/src/main/java/io/github/wimdeblauwe/errorhandlingspringbootstarter/ProblemDetailFactory.java
@@ -44,6 +44,9 @@ public class ProblemDetailFactory {
     }
 
     private String toKebabCase(String input) {
+        if (!properties.isProblemDetailConvertToKebabCase()) {
+            return input;
+        }
         if (input.isEmpty()) {
             return input;
         }

--- a/src/main/java/io/github/wimdeblauwe/errorhandlingspringbootstarter/ProblemDetailFactory.java
+++ b/src/main/java/io/github/wimdeblauwe/errorhandlingspringbootstarter/ProblemDetailFactory.java
@@ -1,0 +1,61 @@
+package io.github.wimdeblauwe.errorhandlingspringbootstarter;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.ProblemDetail;
+import org.springframework.stereotype.Component;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Objects;
+
+@Component
+public class ProblemDetailFactory {
+    private static final Logger LOGGER = LoggerFactory.getLogger(ProblemDetailFactory.class);
+
+    private final ErrorHandlingProperties properties;
+
+    public ProblemDetailFactory(ErrorHandlingProperties properties) {
+        this.properties = properties;
+    }
+
+    public ProblemDetail build(ApiErrorResponse errorResponse) {
+        ProblemDetail problemDetail = ProblemDetail.forStatusAndDetail(Objects.requireNonNull(errorResponse.getHttpStatus()), errorResponse.getMessage());
+        problemDetail.setDetail(errorResponse.getMessage());
+        try {
+            problemDetail.setType(new URI(properties.getProblemDetailTypePrefix() + toKebabCase(errorResponse.getCode())));
+        } catch (URISyntaxException ignored) {
+        }
+
+        HashMap<String, Object> allProperties = new HashMap<>();
+        allProperties.putAll(errorResponse.getProperties());
+        List<ApiFieldError> fieldErrors = errorResponse.getFieldErrors();
+        if (!fieldErrors.isEmpty()) {
+            allProperties.put("fieldErrors", fieldErrors);
+        }
+        List<ApiGlobalError> globalErrors = errorResponse.getGlobalErrors();
+        if (!globalErrors.isEmpty()) {
+            allProperties.put("globalErrors", globalErrors);
+        }
+        problemDetail.setProperties(allProperties);
+
+        return problemDetail;
+    }
+
+    private String toKebabCase(String input) {
+        if (input.isEmpty()) {
+            return input;
+        }
+
+        String result = input
+                .replaceAll("([a-z])([A-Z])", "$1-$2")  // camelCase boundaries
+                .replaceAll("([A-Z])([A-Z][a-z])", "$1-$2")  // handle acronyms
+                .replaceAll("\\s+", "-")  // spaces to hyphens
+                .replaceAll("_", "-")  // underscores to hyphens
+                .toLowerCase();
+        LOGGER.info("{} -> {}", input, result);
+        return result;
+    }
+}

--- a/src/main/java/io/github/wimdeblauwe/errorhandlingspringbootstarter/ProblemDetailFactory.java
+++ b/src/main/java/io/github/wimdeblauwe/errorhandlingspringbootstarter/ProblemDetailFactory.java
@@ -29,8 +29,7 @@ public class ProblemDetailFactory {
         } catch (URISyntaxException ignored) {
         }
 
-        HashMap<String, Object> allProperties = new HashMap<>();
-        allProperties.putAll(errorResponse.getProperties());
+        HashMap<String, Object> allProperties = new HashMap<>(errorResponse.getProperties());
         List<ApiFieldError> fieldErrors = errorResponse.getFieldErrors();
         if (!fieldErrors.isEmpty()) {
             allProperties.put("fieldErrors", fieldErrors);

--- a/src/main/java/io/github/wimdeblauwe/errorhandlingspringbootstarter/ResponseFactory.java
+++ b/src/main/java/io/github/wimdeblauwe/errorhandlingspringbootstarter/ResponseFactory.java
@@ -1,0 +1,13 @@
+package io.github.wimdeblauwe.errorhandlingspringbootstarter;
+
+/**
+ * Factory interface for creating a response object of type T based on an {@link ApiErrorResponse}.
+ * <p>
+ * Implementations of this interface are responsible for transforming the given {@link ApiErrorResponse}
+ * into a response object suitable for the framework or context in which it is used.
+ *
+ * @param <T> the type of the response object to be created
+ */
+public interface ResponseFactory<T> {
+    T create(ApiErrorResponse apiErrorResponse);
+}

--- a/src/main/java/io/github/wimdeblauwe/errorhandlingspringbootstarter/reactive/GlobalErrorWebExceptionHandler.java
+++ b/src/main/java/io/github/wimdeblauwe/errorhandlingspringbootstarter/reactive/GlobalErrorWebExceptionHandler.java
@@ -2,6 +2,8 @@ package io.github.wimdeblauwe.errorhandlingspringbootstarter.reactive;
 
 import io.github.wimdeblauwe.errorhandlingspringbootstarter.ApiErrorResponse;
 import io.github.wimdeblauwe.errorhandlingspringbootstarter.ErrorHandlingFacade;
+import io.github.wimdeblauwe.errorhandlingspringbootstarter.ErrorHandlingProperties;
+import io.github.wimdeblauwe.errorhandlingspringbootstarter.ProblemDetailFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.autoconfigure.web.ErrorProperties;
@@ -21,14 +23,21 @@ public class GlobalErrorWebExceptionHandler extends DefaultErrorWebExceptionHand
     private static final Logger LOGGER = LoggerFactory.getLogger(GlobalErrorWebExceptionHandler.class);
 
     private final ErrorHandlingFacade errorHandlingFacade;
+    private final ErrorHandlingProperties errorHandlingProperties;
+    private final ProblemDetailFactory problemDetailFactory;
+
 
     public GlobalErrorWebExceptionHandler(ErrorAttributes errorAttributes,
                                           WebProperties.Resources resources,
                                           ErrorProperties errorProperties,
                                           ApplicationContext applicationContext,
-                                          ErrorHandlingFacade errorHandlingFacade) {
+                                          ErrorHandlingFacade errorHandlingFacade,
+                                          ErrorHandlingProperties errorHandlingProperties,
+                                          ProblemDetailFactory problemDetailFactory) {
         super(errorAttributes, resources, errorProperties, applicationContext);
         this.errorHandlingFacade = errorHandlingFacade;
+        this.errorHandlingProperties = errorHandlingProperties;
+        this.problemDetailFactory = problemDetailFactory;
     }
 
     @Override
@@ -49,8 +58,14 @@ public class GlobalErrorWebExceptionHandler extends DefaultErrorWebExceptionHand
 
         ApiErrorResponse errorResponse = errorHandlingFacade.handle(Objects.requireNonNull(exception));
 
-        return ServerResponse.status(Objects.requireNonNull(errorResponse.getHttpStatus()))
-                             .contentType(MediaType.APPLICATION_JSON)
-                             .body(BodyInserters.fromValue(errorResponse));
+        if (errorHandlingProperties.isUseProblemDetailFormat()) {
+            return ServerResponse.status(Objects.requireNonNull(errorResponse.getHttpStatus()))
+                                 .contentType(MediaType.APPLICATION_PROBLEM_JSON)
+                                 .body(BodyInserters.fromValue(problemDetailFactory.build(errorResponse)));
+        } else {
+            return ServerResponse.status(Objects.requireNonNull(errorResponse.getHttpStatus()))
+                                 .contentType(MediaType.APPLICATION_JSON)
+                                 .body(BodyInserters.fromValue(errorResponse));
+        }
     }
 }

--- a/src/main/java/io/github/wimdeblauwe/errorhandlingspringbootstarter/reactive/GlobalErrorWebExceptionHandler.java
+++ b/src/main/java/io/github/wimdeblauwe/errorhandlingspringbootstarter/reactive/GlobalErrorWebExceptionHandler.java
@@ -2,8 +2,6 @@ package io.github.wimdeblauwe.errorhandlingspringbootstarter.reactive;
 
 import io.github.wimdeblauwe.errorhandlingspringbootstarter.ApiErrorResponse;
 import io.github.wimdeblauwe.errorhandlingspringbootstarter.ErrorHandlingFacade;
-import io.github.wimdeblauwe.errorhandlingspringbootstarter.ErrorHandlingProperties;
-import io.github.wimdeblauwe.errorhandlingspringbootstarter.ProblemDetailFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.autoconfigure.web.ErrorProperties;
@@ -11,8 +9,6 @@ import org.springframework.boot.autoconfigure.web.WebProperties;
 import org.springframework.boot.webflux.autoconfigure.error.DefaultErrorWebExceptionHandler;
 import org.springframework.boot.webflux.error.ErrorAttributes;
 import org.springframework.context.ApplicationContext;
-import org.springframework.http.MediaType;
-import org.springframework.web.reactive.function.BodyInserters;
 import org.springframework.web.reactive.function.server.*;
 import reactor.core.publisher.Mono;
 
@@ -23,21 +19,17 @@ public class GlobalErrorWebExceptionHandler extends DefaultErrorWebExceptionHand
     private static final Logger LOGGER = LoggerFactory.getLogger(GlobalErrorWebExceptionHandler.class);
 
     private final ErrorHandlingFacade errorHandlingFacade;
-    private final ErrorHandlingProperties errorHandlingProperties;
-    private final ProblemDetailFactory problemDetailFactory;
-
+    private final ReactiveResponseFactory responseFactory;
 
     public GlobalErrorWebExceptionHandler(ErrorAttributes errorAttributes,
                                           WebProperties.Resources resources,
                                           ErrorProperties errorProperties,
                                           ApplicationContext applicationContext,
                                           ErrorHandlingFacade errorHandlingFacade,
-                                          ErrorHandlingProperties errorHandlingProperties,
-                                          ProblemDetailFactory problemDetailFactory) {
+                                          ReactiveResponseFactory responseFactory) {
         super(errorAttributes, resources, errorProperties, applicationContext);
         this.errorHandlingFacade = errorHandlingFacade;
-        this.errorHandlingProperties = errorHandlingProperties;
-        this.problemDetailFactory = problemDetailFactory;
+        this.responseFactory = responseFactory;
     }
 
     @Override
@@ -58,14 +50,6 @@ public class GlobalErrorWebExceptionHandler extends DefaultErrorWebExceptionHand
 
         ApiErrorResponse errorResponse = errorHandlingFacade.handle(Objects.requireNonNull(exception));
 
-        if (errorHandlingProperties.isUseProblemDetailFormat()) {
-            return ServerResponse.status(Objects.requireNonNull(errorResponse.getHttpStatus()))
-                                 .contentType(MediaType.APPLICATION_PROBLEM_JSON)
-                                 .body(BodyInserters.fromValue(problemDetailFactory.build(errorResponse)));
-        } else {
-            return ServerResponse.status(Objects.requireNonNull(errorResponse.getHttpStatus()))
-                                 .contentType(MediaType.APPLICATION_JSON)
-                                 .body(BodyInserters.fromValue(errorResponse));
-        }
+        return responseFactory.create(errorResponse);
     }
 }

--- a/src/main/java/io/github/wimdeblauwe/errorhandlingspringbootstarter/reactive/ReactiveDefaultResponseFactory.java
+++ b/src/main/java/io/github/wimdeblauwe/errorhandlingspringbootstarter/reactive/ReactiveDefaultResponseFactory.java
@@ -1,0 +1,18 @@
+package io.github.wimdeblauwe.errorhandlingspringbootstarter.reactive;
+
+import io.github.wimdeblauwe.errorhandlingspringbootstarter.ApiErrorResponse;
+import org.springframework.http.MediaType;
+import org.springframework.web.reactive.function.BodyInserters;
+import org.springframework.web.reactive.function.server.ServerResponse;
+import reactor.core.publisher.Mono;
+
+import java.util.Objects;
+
+public class ReactiveDefaultResponseFactory implements ReactiveResponseFactory {
+    @Override
+    public Mono<ServerResponse> create(ApiErrorResponse errorResponse) {
+        return ServerResponse.status(Objects.requireNonNull(errorResponse.getHttpStatus()))
+                             .contentType(MediaType.APPLICATION_JSON)
+                             .body(BodyInserters.fromValue(errorResponse));
+    }
+}

--- a/src/main/java/io/github/wimdeblauwe/errorhandlingspringbootstarter/reactive/ReactiveErrorHandlingConfiguration.java
+++ b/src/main/java/io/github/wimdeblauwe/errorhandlingspringbootstarter/reactive/ReactiveErrorHandlingConfiguration.java
@@ -66,16 +66,15 @@ public class ReactiveErrorHandlingConfiguration extends AbstractErrorHandlingCon
                                                                          ServerCodecConfigurer serverCodecConfigurer,
                                                                          ApplicationContext applicationContext,
                                                                          ErrorHandlingFacade errorHandlingFacade,
-                                                                         ErrorHandlingProperties errorHandlingProperties,
-                                                                         ProblemDetailFactory problemDetailFactory) {
+                                                                         ReactiveResponseFactory responseEntityFactory) {
 
         GlobalErrorWebExceptionHandler exceptionHandler = new GlobalErrorWebExceptionHandler(errorAttributes,
                                                                                              webProperties.getResources(),
                                                                                              webProperties.getError(),
                                                                                              applicationContext,
                                                                                              errorHandlingFacade,
-                                                                                             errorHandlingProperties,
-                                                                                             problemDetailFactory);
+                                                                                             responseEntityFactory
+        );
         exceptionHandler.setViewResolvers(viewResolvers.orderedStream().collect(Collectors.toList()));
         exceptionHandler.setMessageWriters(serverCodecConfigurer.getWriters());
         exceptionHandler.setMessageReaders(serverCodecConfigurer.getReaders());
@@ -84,7 +83,17 @@ public class ReactiveErrorHandlingConfiguration extends AbstractErrorHandlingCon
 
     @Bean
     @ConditionalOnMissingBean
-    public ProblemDetailFactory responseEntityFactory(ErrorHandlingProperties errorHandlingProperties) {
+    public ReactiveResponseFactory responseEntityFactory(ErrorHandlingProperties errorHandlingProperties, ProblemDetailFactory problemDetailFactory) {
+        if (errorHandlingProperties.isUseProblemDetailFormat()) {
+            return new ReactiveProblemDetailResponseFactory(problemDetailFactory);
+        } else {
+            return new ReactiveDefaultResponseFactory();
+        }
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public ProblemDetailFactory problemDetailFactory(ErrorHandlingProperties errorHandlingProperties) {
         return new ProblemDetailFactory(errorHandlingProperties);
     }
 

--- a/src/main/java/io/github/wimdeblauwe/errorhandlingspringbootstarter/reactive/ReactiveErrorHandlingConfiguration.java
+++ b/src/main/java/io/github/wimdeblauwe/errorhandlingspringbootstarter/reactive/ReactiveErrorHandlingConfiguration.java
@@ -65,17 +65,27 @@ public class ReactiveErrorHandlingConfiguration extends AbstractErrorHandlingCon
                                                                          ObjectProvider<ViewResolver> viewResolvers,
                                                                          ServerCodecConfigurer serverCodecConfigurer,
                                                                          ApplicationContext applicationContext,
-                                                                         ErrorHandlingFacade errorHandlingFacade) {
+                                                                         ErrorHandlingFacade errorHandlingFacade,
+                                                                         ErrorHandlingProperties errorHandlingProperties,
+                                                                         ProblemDetailFactory problemDetailFactory) {
 
         GlobalErrorWebExceptionHandler exceptionHandler = new GlobalErrorWebExceptionHandler(errorAttributes,
                                                                                              webProperties.getResources(),
                                                                                              webProperties.getError(),
                                                                                              applicationContext,
-                                                                                             errorHandlingFacade);
+                                                                                             errorHandlingFacade,
+                                                                                             errorHandlingProperties,
+                                                                                             problemDetailFactory);
         exceptionHandler.setViewResolvers(viewResolvers.orderedStream().collect(Collectors.toList()));
         exceptionHandler.setMessageWriters(serverCodecConfigurer.getWriters());
         exceptionHandler.setMessageReaders(serverCodecConfigurer.getReaders());
         return exceptionHandler;
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public ProblemDetailFactory responseEntityFactory(ErrorHandlingProperties errorHandlingProperties) {
+        return new ProblemDetailFactory(errorHandlingProperties);
     }
 
     @Bean

--- a/src/main/java/io/github/wimdeblauwe/errorhandlingspringbootstarter/reactive/ReactiveProblemDetailResponseFactory.java
+++ b/src/main/java/io/github/wimdeblauwe/errorhandlingspringbootstarter/reactive/ReactiveProblemDetailResponseFactory.java
@@ -1,0 +1,25 @@
+package io.github.wimdeblauwe.errorhandlingspringbootstarter.reactive;
+
+import io.github.wimdeblauwe.errorhandlingspringbootstarter.ApiErrorResponse;
+import io.github.wimdeblauwe.errorhandlingspringbootstarter.ProblemDetailFactory;
+import org.springframework.http.MediaType;
+import org.springframework.web.reactive.function.BodyInserters;
+import org.springframework.web.reactive.function.server.ServerResponse;
+import reactor.core.publisher.Mono;
+
+import java.util.Objects;
+
+public class ReactiveProblemDetailResponseFactory implements ReactiveResponseFactory {
+    private final ProblemDetailFactory problemDetailFactory;
+
+    public ReactiveProblemDetailResponseFactory(ProblemDetailFactory problemDetailFactory) {
+        this.problemDetailFactory = problemDetailFactory;
+    }
+
+    @Override
+    public Mono<ServerResponse> create(ApiErrorResponse errorResponse) {
+        return ServerResponse.status(Objects.requireNonNull(errorResponse.getHttpStatus()))
+                             .contentType(MediaType.APPLICATION_PROBLEM_JSON)
+                             .body(BodyInserters.fromValue(problemDetailFactory.build(errorResponse)));
+    }
+}

--- a/src/main/java/io/github/wimdeblauwe/errorhandlingspringbootstarter/reactive/ReactiveResponseFactory.java
+++ b/src/main/java/io/github/wimdeblauwe/errorhandlingspringbootstarter/reactive/ReactiveResponseFactory.java
@@ -1,0 +1,15 @@
+package io.github.wimdeblauwe.errorhandlingspringbootstarter.reactive;
+
+import io.github.wimdeblauwe.errorhandlingspringbootstarter.ResponseFactory;
+import org.springframework.web.reactive.function.server.ServerResponse;
+import reactor.core.publisher.Mono;
+
+/**
+ * ReactiveResponseFactory is a specialized factory interface for creating reactive responses
+ * using the Project Reactor {@link Mono} type and Spring WebFlux's {@link ServerResponse}.
+ * <p>
+ * Implementations of this interface are responsible for transforming an {@link io.github.wimdeblauwe.errorhandlingspringbootstarter.ApiErrorResponse ApiErrorResponse}
+ * into a reactive response suitable for handling WebFlux-based server errors.
+ */
+public interface ReactiveResponseFactory extends ResponseFactory<Mono<ServerResponse>> {
+}

--- a/src/main/java/io/github/wimdeblauwe/errorhandlingspringbootstarter/servlet/ErrorHandlingControllerAdvice.java
+++ b/src/main/java/io/github/wimdeblauwe/errorhandlingspringbootstarter/servlet/ErrorHandlingControllerAdvice.java
@@ -4,8 +4,6 @@ import io.github.wimdeblauwe.errorhandlingspringbootstarter.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
-import org.springframework.http.MediaType;
-import org.springframework.http.ProblemDetail;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -13,7 +11,6 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.context.request.WebRequest;
 
 import java.util.Locale;
-import java.util.Objects;
 
 @ControllerAdvice(annotations = RestController.class)
 @ConditionalOnWebApplication(type = ConditionalOnWebApplication.Type.SERVLET)
@@ -21,13 +18,11 @@ public class ErrorHandlingControllerAdvice {
     private static final Logger LOGGER = LoggerFactory.getLogger(ErrorHandlingControllerAdvice.class);
 
     private final ErrorHandlingFacade errorHandlingFacade;
-    private final ErrorHandlingProperties errorHandlingProperties;
-    private final ProblemDetailFactory problemDetailFactory;
+    private final ServletResponseFactory responseFactory;
 
-    public ErrorHandlingControllerAdvice(ErrorHandlingFacade errorHandlingFacade, ErrorHandlingProperties errorHandlingProperties, ProblemDetailFactory problemDetailFactory) {
+    public ErrorHandlingControllerAdvice(ErrorHandlingFacade errorHandlingFacade, ServletResponseFactory responseFactory) {
         this.errorHandlingFacade = errorHandlingFacade;
-        this.errorHandlingProperties = errorHandlingProperties;
-        this.problemDetailFactory = problemDetailFactory;
+        this.responseFactory = responseFactory;
     }
 
     @ExceptionHandler
@@ -37,15 +32,6 @@ public class ErrorHandlingControllerAdvice {
 
         ApiErrorResponse errorResponse = errorHandlingFacade.handle(exception);
 
-        if (errorHandlingProperties.isUseProblemDetailFormat()) {
-            ProblemDetail problemDetail = problemDetailFactory.build(errorResponse);
-            return ResponseEntity.status(Objects.requireNonNull(errorResponse.getHttpStatus()))
-                                 .contentType(MediaType.APPLICATION_PROBLEM_JSON)
-                                 .body(problemDetail);
-        } else {
-            return ResponseEntity.status(Objects.requireNonNull(errorResponse.getHttpStatus()))
-                                 .contentType(MediaType.APPLICATION_JSON)
-                                 .body(errorResponse);
-        }
+        return responseFactory.create(errorResponse);
     }
 }

--- a/src/main/java/io/github/wimdeblauwe/errorhandlingspringbootstarter/servlet/ErrorHandlingControllerAdvice.java
+++ b/src/main/java/io/github/wimdeblauwe/errorhandlingspringbootstarter/servlet/ErrorHandlingControllerAdvice.java
@@ -1,11 +1,11 @@
 package io.github.wimdeblauwe.errorhandlingspringbootstarter.servlet;
 
-import io.github.wimdeblauwe.errorhandlingspringbootstarter.ApiErrorResponse;
-import io.github.wimdeblauwe.errorhandlingspringbootstarter.ErrorHandlingFacade;
+import io.github.wimdeblauwe.errorhandlingspringbootstarter.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
 import org.springframework.http.MediaType;
+import org.springframework.http.ProblemDetail;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -21,9 +21,13 @@ public class ErrorHandlingControllerAdvice {
     private static final Logger LOGGER = LoggerFactory.getLogger(ErrorHandlingControllerAdvice.class);
 
     private final ErrorHandlingFacade errorHandlingFacade;
+    private final ErrorHandlingProperties errorHandlingProperties;
+    private final ProblemDetailFactory problemDetailFactory;
 
-    public ErrorHandlingControllerAdvice(ErrorHandlingFacade errorHandlingFacade) {
+    public ErrorHandlingControllerAdvice(ErrorHandlingFacade errorHandlingFacade, ErrorHandlingProperties errorHandlingProperties, ProblemDetailFactory problemDetailFactory) {
         this.errorHandlingFacade = errorHandlingFacade;
+        this.errorHandlingProperties = errorHandlingProperties;
+        this.problemDetailFactory = problemDetailFactory;
     }
 
     @ExceptionHandler
@@ -33,8 +37,15 @@ public class ErrorHandlingControllerAdvice {
 
         ApiErrorResponse errorResponse = errorHandlingFacade.handle(exception);
 
-        return ResponseEntity.status(Objects.requireNonNull(errorResponse.getHttpStatus()))
-                             .contentType(MediaType.APPLICATION_JSON)
-                             .body(errorResponse);
+        if (errorHandlingProperties.isUseProblemDetailFormat()) {
+            ProblemDetail problemDetail = problemDetailFactory.build(errorResponse);
+            return ResponseEntity.status(Objects.requireNonNull(errorResponse.getHttpStatus()))
+                                 .contentType(MediaType.APPLICATION_PROBLEM_JSON)
+                                 .body(problemDetail);
+        } else {
+            return ResponseEntity.status(Objects.requireNonNull(errorResponse.getHttpStatus()))
+                                 .contentType(MediaType.APPLICATION_JSON)
+                                 .body(errorResponse);
+        }
     }
 }

--- a/src/main/java/io/github/wimdeblauwe/errorhandlingspringbootstarter/servlet/ServletDefaultResponseFactory.java
+++ b/src/main/java/io/github/wimdeblauwe/errorhandlingspringbootstarter/servlet/ServletDefaultResponseFactory.java
@@ -1,0 +1,17 @@
+package io.github.wimdeblauwe.errorhandlingspringbootstarter.servlet;
+
+import io.github.wimdeblauwe.errorhandlingspringbootstarter.ApiErrorResponse;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+
+import java.util.Objects;
+
+class ServletDefaultResponseFactory implements ServletResponseFactory {
+
+    @Override
+    public ResponseEntity<ApiErrorResponse> create(ApiErrorResponse errorResponse) {
+        return ResponseEntity.status(Objects.requireNonNull(errorResponse.getHttpStatus()))
+                             .contentType(MediaType.APPLICATION_JSON)
+                             .body(errorResponse);
+    }
+}

--- a/src/main/java/io/github/wimdeblauwe/errorhandlingspringbootstarter/servlet/ServletErrorHandlingConfiguration.java
+++ b/src/main/java/io/github/wimdeblauwe/errorhandlingspringbootstarter/servlet/ServletErrorHandlingConfiguration.java
@@ -39,8 +39,16 @@ public class ServletErrorHandlingConfiguration extends AbstractErrorHandlingConf
 
     @Bean
     @ConditionalOnMissingBean
-    public ErrorHandlingControllerAdvice errorHandlingControllerAdvice(ErrorHandlingFacade errorHandlingFacade) {
-        return new ErrorHandlingControllerAdvice(errorHandlingFacade);
+    public ErrorHandlingControllerAdvice errorHandlingControllerAdvice(ErrorHandlingFacade errorHandlingFacade,
+                                                                       ErrorHandlingProperties errorHandlingProperties,
+                                                                       ProblemDetailFactory problemDetailFactory) {
+        return new ErrorHandlingControllerAdvice(errorHandlingFacade, errorHandlingProperties, problemDetailFactory);
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public ProblemDetailFactory responseEntityFactory(ErrorHandlingProperties errorHandlingProperties) {
+        return new ProblemDetailFactory(errorHandlingProperties);
     }
 
     @Bean

--- a/src/main/java/io/github/wimdeblauwe/errorhandlingspringbootstarter/servlet/ServletErrorHandlingConfiguration.java
+++ b/src/main/java/io/github/wimdeblauwe/errorhandlingspringbootstarter/servlet/ServletErrorHandlingConfiguration.java
@@ -1,6 +1,5 @@
 package io.github.wimdeblauwe.errorhandlingspringbootstarter.servlet;
 
-import tools.jackson.databind.ObjectMapper;
 import io.github.wimdeblauwe.errorhandlingspringbootstarter.*;
 import io.github.wimdeblauwe.errorhandlingspringbootstarter.handler.MissingRequestValueExceptionHandler;
 import io.github.wimdeblauwe.errorhandlingspringbootstarter.mapper.ErrorCodeMapper;
@@ -16,6 +15,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.PropertySource;
 import org.springframework.core.Ordered;
+import tools.jackson.databind.ObjectMapper;
 
 @AutoConfiguration
 @ConditionalOnWebApplication(type = ConditionalOnWebApplication.Type.SERVLET)
@@ -40,14 +40,24 @@ public class ServletErrorHandlingConfiguration extends AbstractErrorHandlingConf
     @Bean
     @ConditionalOnMissingBean
     public ErrorHandlingControllerAdvice errorHandlingControllerAdvice(ErrorHandlingFacade errorHandlingFacade,
-                                                                       ErrorHandlingProperties errorHandlingProperties,
-                                                                       ProblemDetailFactory problemDetailFactory) {
-        return new ErrorHandlingControllerAdvice(errorHandlingFacade, errorHandlingProperties, problemDetailFactory);
+                                                                       ServletResponseFactory responseEntityFactory) {
+        return new ErrorHandlingControllerAdvice(errorHandlingFacade, responseEntityFactory);
     }
 
     @Bean
     @ConditionalOnMissingBean
-    public ProblemDetailFactory responseEntityFactory(ErrorHandlingProperties errorHandlingProperties) {
+    public ServletResponseFactory responseEntityFactory(ErrorHandlingProperties properties,
+                                                        ProblemDetailFactory problemDetailFactory) {
+        if (properties.isUseProblemDetailFormat()) {
+            return new ServletProblemDetailResponseFactory(problemDetailFactory);
+        } else {
+            return new ServletDefaultResponseFactory();
+        }
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public ProblemDetailFactory problemDetailFactory(ErrorHandlingProperties errorHandlingProperties) {
         return new ProblemDetailFactory(errorHandlingProperties);
     }
 

--- a/src/main/java/io/github/wimdeblauwe/errorhandlingspringbootstarter/servlet/ServletProblemDetailResponseFactory.java
+++ b/src/main/java/io/github/wimdeblauwe/errorhandlingspringbootstarter/servlet/ServletProblemDetailResponseFactory.java
@@ -1,0 +1,27 @@
+package io.github.wimdeblauwe.errorhandlingspringbootstarter.servlet;
+
+import io.github.wimdeblauwe.errorhandlingspringbootstarter.ApiErrorResponse;
+import io.github.wimdeblauwe.errorhandlingspringbootstarter.ProblemDetailFactory;
+import org.springframework.http.MediaType;
+import org.springframework.http.ProblemDetail;
+import org.springframework.http.ResponseEntity;
+
+import java.util.Objects;
+
+class ServletProblemDetailResponseFactory implements ServletResponseFactory {
+
+    private final ProblemDetailFactory problemDetailFactory;
+
+    public ServletProblemDetailResponseFactory(ProblemDetailFactory problemDetailFactory) {
+        this.problemDetailFactory = problemDetailFactory;
+    }
+
+    @Override
+    public ResponseEntity<?> create(ApiErrorResponse errorResponse) {
+        ProblemDetail problemDetail = problemDetailFactory.build(errorResponse);
+        return ResponseEntity.status(Objects.requireNonNull(errorResponse.getHttpStatus()))
+                             .contentType(MediaType.APPLICATION_PROBLEM_JSON)
+                             .body(problemDetail);
+    }
+
+}

--- a/src/main/java/io/github/wimdeblauwe/errorhandlingspringbootstarter/servlet/ServletResponseFactory.java
+++ b/src/main/java/io/github/wimdeblauwe/errorhandlingspringbootstarter/servlet/ServletResponseFactory.java
@@ -1,0 +1,14 @@
+package io.github.wimdeblauwe.errorhandlingspringbootstarter.servlet;
+
+import io.github.wimdeblauwe.errorhandlingspringbootstarter.ResponseFactory;
+import org.springframework.http.ResponseEntity;
+
+/**
+ * A specialized {@link ResponseFactory} interface for creating {@link ResponseEntity} objects
+ * from instances of {@link io.github.wimdeblauwe.errorhandlingspringbootstarter.ApiErrorResponse ApiErrorResponse} within the context of a servlet-based web application.
+ * <p>
+ * Implementations of this interface define how <code>ApiErrorResponse</code> objects should be transformed
+ * into {@link ResponseEntity} objects to work seamlessly with servlet environments in Spring applications.
+ */
+public interface ServletResponseFactory extends ResponseFactory<ResponseEntity<?>> {
+}

--- a/src/test/java/io/github/wimdeblauwe/errorhandlingspringbootstarter/handler/ConstraintViolationApiExceptionHandlerTest.java
+++ b/src/test/java/io/github/wimdeblauwe/errorhandlingspringbootstarter/handler/ConstraintViolationApiExceptionHandlerTest.java
@@ -8,6 +8,7 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
@@ -17,6 +18,7 @@ import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.stereotype.Service;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
@@ -361,28 +363,31 @@ class ConstraintViolationApiExceptionHandlerTest {
         ;
     }
 
-    @Test
-    @WithMockUser
-    void testConstraintViolationExceptionUsingProblemDetailFormat(@Autowired ErrorHandlingProperties properties) throws Exception {
-        properties.setUseProblemDetailFormat(true);
-        mockMvc.perform(post("/test/validation")
-                                .contentType(MediaType.APPLICATION_JSON)
-                                .content("{\"value2\": \"\"}")
-                                .with(csrf()))
-               .andExpect(status().isBadRequest())
-                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_PROBLEM_JSON))
-               .andExpect(jsonPath("title").value("Bad Request"))
-               .andExpect(jsonPath("type").value("validation-failed"))
-               .andExpect(jsonPath("detail").value("Validation failed. Error count: 3"))
-               .andExpect(jsonPath("fieldErrors", hasSize(2)))
-               .andExpect(jsonPath("fieldErrors..code", allOf(hasItem("REQUIRED_NOT_NULL"), hasItem("INVALID_SIZE"))))
-               .andExpect(jsonPath("fieldErrors..property", allOf(hasItem("value"), hasItem("value2"))))
-               .andExpect(jsonPath("fieldErrors..message", allOf(hasItem("must not be null"), hasItem("size must be between 1 and 255"))))
-               .andExpect(jsonPath("fieldErrors..rejectedValue", allOf(hasItem(Matchers.nullValue()), hasItem(""))))
-               .andExpect(jsonPath("globalErrors", hasSize(1)))
-               .andExpect(jsonPath("globalErrors..code", allOf(hasItem("ValuesEqual"))))
-               .andExpect(jsonPath("globalErrors..message", allOf(hasItem("Values not equal"))))
-        ;
+    @Nested
+    @TestPropertySource(properties = "error.handling.use-problem-detail-format=true")
+    class ProblemDetailsFormatTests {
+        @Test
+        @WithMockUser
+        void testConstraintViolationExceptionUsingProblemDetailFormat() throws Exception {
+            mockMvc.perform(post("/test/validation")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content("{\"value2\": \"\"}")
+                                    .with(csrf()))
+                   .andExpect(status().isBadRequest())
+                   .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_PROBLEM_JSON))
+                   .andExpect(jsonPath("title").value("Bad Request"))
+                   .andExpect(jsonPath("type").value("validation-failed"))
+                   .andExpect(jsonPath("detail").value("Validation failed. Error count: 3"))
+                   .andExpect(jsonPath("fieldErrors", hasSize(2)))
+                   .andExpect(jsonPath("fieldErrors..code", allOf(hasItem("REQUIRED_NOT_NULL"), hasItem("INVALID_SIZE"))))
+                   .andExpect(jsonPath("fieldErrors..property", allOf(hasItem("value"), hasItem("value2"))))
+                   .andExpect(jsonPath("fieldErrors..message", allOf(hasItem("must not be null"), hasItem("size must be between 1 and 255"))))
+                   .andExpect(jsonPath("fieldErrors..rejectedValue", allOf(hasItem(Matchers.nullValue()), hasItem(""))))
+                   .andExpect(jsonPath("globalErrors", hasSize(1)))
+                   .andExpect(jsonPath("globalErrors..code", allOf(hasItem("ValuesEqual"))))
+                   .andExpect(jsonPath("globalErrors..message", allOf(hasItem("Values not equal"))))
+            ;
+        }
     }
 
     @RestController

--- a/src/test/java/io/github/wimdeblauwe/errorhandlingspringbootstarter/handler/ConstraintViolationApiExceptionHandlerTest.java
+++ b/src/test/java/io/github/wimdeblauwe/errorhandlingspringbootstarter/handler/ConstraintViolationApiExceptionHandlerTest.java
@@ -35,8 +35,7 @@ import static org.springframework.security.test.web.servlet.request.SecurityMock
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @WebMvcTest
 @ContextConfiguration(classes = {
@@ -359,6 +358,30 @@ class ConstraintViolationApiExceptionHandlerTest {
                .andExpect(jsonPath("fieldErrors", hasSize(1)))
                .andExpect(jsonPath("fieldErrors[0].property", equalTo("fieldAtLevel2")))
                .andExpect(jsonPath("fieldErrors[0].path").doesNotExist())
+        ;
+    }
+
+    @Test
+    @WithMockUser
+    void testConstraintViolationExceptionUsingProblemDetailFormat(@Autowired ErrorHandlingProperties properties) throws Exception {
+        properties.setUseProblemDetailFormat(true);
+        mockMvc.perform(post("/test/validation")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content("{\"value2\": \"\"}")
+                                .with(csrf()))
+               .andExpect(status().isBadRequest())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_PROBLEM_JSON))
+               .andExpect(jsonPath("title").value("Bad Request"))
+               .andExpect(jsonPath("type").value("validation-failed"))
+               .andExpect(jsonPath("detail").value("Validation failed. Error count: 3"))
+               .andExpect(jsonPath("fieldErrors", hasSize(2)))
+               .andExpect(jsonPath("fieldErrors..code", allOf(hasItem("REQUIRED_NOT_NULL"), hasItem("INVALID_SIZE"))))
+               .andExpect(jsonPath("fieldErrors..property", allOf(hasItem("value"), hasItem("value2"))))
+               .andExpect(jsonPath("fieldErrors..message", allOf(hasItem("must not be null"), hasItem("size must be between 1 and 255"))))
+               .andExpect(jsonPath("fieldErrors..rejectedValue", allOf(hasItem(Matchers.nullValue()), hasItem(""))))
+               .andExpect(jsonPath("globalErrors", hasSize(1)))
+               .andExpect(jsonPath("globalErrors..code", allOf(hasItem("ValuesEqual"))))
+               .andExpect(jsonPath("globalErrors..message", allOf(hasItem("Values not equal"))))
         ;
     }
 

--- a/src/test/java/io/github/wimdeblauwe/errorhandlingspringbootstarter/handler/CustomApiExceptionHandlerDocumentation.java
+++ b/src/test/java/io/github/wimdeblauwe/errorhandlingspringbootstarter/handler/CustomApiExceptionHandlerDocumentation.java
@@ -1,6 +1,5 @@
 package io.github.wimdeblauwe.errorhandlingspringbootstarter.handler;
 
-import io.github.wimdeblauwe.errorhandlingspringbootstarter.servlet.ServletErrorHandlingConfiguration;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;

--- a/src/test/java/io/github/wimdeblauwe/errorhandlingspringbootstarter/handler/ObjectOptimisticLockingFailureApiExceptionHandlerTest.java
+++ b/src/test/java/io/github/wimdeblauwe/errorhandlingspringbootstarter/handler/ObjectOptimisticLockingFailureApiExceptionHandlerTest.java
@@ -1,11 +1,14 @@
 package io.github.wimdeblauwe.errorhandlingspringbootstarter.handler;
 
 
+import io.github.wimdeblauwe.errorhandlingspringbootstarter.ErrorHandlingProperties;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.http.MediaType;
 import org.springframework.orm.ObjectOptimisticLockingFailureException;
 import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -13,12 +16,12 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @WebMvcTest
 @ContextConfiguration(classes = {
         ObjectOptimisticLockingFailureApiExceptionHandlerTest.TestController.class})
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
 class ObjectOptimisticLockingFailureApiExceptionHandlerTest {
 
     @Autowired
@@ -31,6 +34,37 @@ class ObjectOptimisticLockingFailureApiExceptionHandlerTest {
                .andExpect(status().isConflict())
                .andExpect(jsonPath("code").value("OPTIMISTIC_LOCKING_ERROR"))
                .andExpect(jsonPath("message").value("Object of class [com.example.user.User] with identifier [1]: optimistic locking failed"))
+               .andExpect(jsonPath("persistentClassName").value("com.example.user.User"))
+               .andExpect(jsonPath("identifier").value("1"))
+        ;
+    }
+
+    @Test
+    @WithMockUser
+    void testOOLFWithProblemDetailFormat(@Autowired ErrorHandlingProperties properties) throws Exception {
+        properties.setUseProblemDetailFormat(true);
+        mockMvc.perform(get("/test/object-optimistic-locking-failure"))
+               .andExpect(status().isConflict())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_PROBLEM_JSON))
+               .andExpect(jsonPath("title").value("Conflict"))
+               .andExpect(jsonPath("type").value("optimistic-locking-error"))
+               .andExpect(jsonPath("detail").value("Object of class [com.example.user.User] with identifier [1]: optimistic locking failed"))
+               .andExpect(jsonPath("persistentClassName").value("com.example.user.User"))
+               .andExpect(jsonPath("identifier").value("1"))
+        ;
+    }
+
+    @Test
+    @WithMockUser
+    void testOOLFWithProblemDetailFormatAndTypePrefix(@Autowired ErrorHandlingProperties properties) throws Exception {
+        properties.setUseProblemDetailFormat(true);
+        properties.setProblemDetailTypePrefix("https://example.org/");
+        mockMvc.perform(get("/test/object-optimistic-locking-failure"))
+               .andExpect(status().isConflict())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_PROBLEM_JSON))
+               .andExpect(jsonPath("title").value("Conflict"))
+               .andExpect(jsonPath("type").value("https://example.org/optimistic-locking-error"))
+               .andExpect(jsonPath("detail").value("Object of class [com.example.user.User] with identifier [1]: optimistic locking failed"))
                .andExpect(jsonPath("persistentClassName").value("com.example.user.User"))
                .andExpect(jsonPath("identifier").value("1"))
         ;

--- a/src/test/java/io/github/wimdeblauwe/errorhandlingspringbootstarter/handler/ObjectOptimisticLockingFailureApiExceptionHandlerTest.java
+++ b/src/test/java/io/github/wimdeblauwe/errorhandlingspringbootstarter/handler/ObjectOptimisticLockingFailureApiExceptionHandlerTest.java
@@ -2,6 +2,7 @@ package io.github.wimdeblauwe.errorhandlingspringbootstarter.handler;
 
 
 import io.github.wimdeblauwe.errorhandlingspringbootstarter.ErrorHandlingProperties;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
@@ -10,6 +11,7 @@ import org.springframework.orm.ObjectOptimisticLockingFailureException;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -39,35 +41,37 @@ class ObjectOptimisticLockingFailureApiExceptionHandlerTest {
         ;
     }
 
-    @Test
-    @WithMockUser
-    void testOOLFWithProblemDetailFormat(@Autowired ErrorHandlingProperties properties) throws Exception {
-        properties.setUseProblemDetailFormat(true);
-        mockMvc.perform(get("/test/object-optimistic-locking-failure"))
-               .andExpect(status().isConflict())
-                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_PROBLEM_JSON))
-               .andExpect(jsonPath("title").value("Conflict"))
-               .andExpect(jsonPath("type").value("optimistic-locking-error"))
-               .andExpect(jsonPath("detail").value("Object of class [com.example.user.User] with identifier [1]: optimistic locking failed"))
-               .andExpect(jsonPath("persistentClassName").value("com.example.user.User"))
-               .andExpect(jsonPath("identifier").value("1"))
-        ;
-    }
+    @Nested
+    @TestPropertySource(properties = "error.handling.use-problem-detail-format=true")
+    class ProblemDetailsFormatTests {
+        @Test
+        @WithMockUser
+        void testOOLFWithProblemDetailFormat() throws Exception {
+            mockMvc.perform(get("/test/object-optimistic-locking-failure"))
+                   .andExpect(status().isConflict())
+                   .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_PROBLEM_JSON))
+                   .andExpect(jsonPath("title").value("Conflict"))
+                   .andExpect(jsonPath("type").value("optimistic-locking-error"))
+                   .andExpect(jsonPath("detail").value("Object of class [com.example.user.User] with identifier [1]: optimistic locking failed"))
+                   .andExpect(jsonPath("persistentClassName").value("com.example.user.User"))
+                   .andExpect(jsonPath("identifier").value("1"))
+            ;
+        }
 
-    @Test
-    @WithMockUser
-    void testOOLFWithProblemDetailFormatAndTypePrefix(@Autowired ErrorHandlingProperties properties) throws Exception {
-        properties.setUseProblemDetailFormat(true);
-        properties.setProblemDetailTypePrefix("https://example.org/");
-        mockMvc.perform(get("/test/object-optimistic-locking-failure"))
-               .andExpect(status().isConflict())
-                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_PROBLEM_JSON))
-               .andExpect(jsonPath("title").value("Conflict"))
-               .andExpect(jsonPath("type").value("https://example.org/optimistic-locking-error"))
-               .andExpect(jsonPath("detail").value("Object of class [com.example.user.User] with identifier [1]: optimistic locking failed"))
-               .andExpect(jsonPath("persistentClassName").value("com.example.user.User"))
-               .andExpect(jsonPath("identifier").value("1"))
-        ;
+        @Test
+        @WithMockUser
+        void testOOLFWithProblemDetailFormatAndTypePrefix(@Autowired ErrorHandlingProperties properties) throws Exception {
+            properties.setProblemDetailTypePrefix("https://example.org/");
+            mockMvc.perform(get("/test/object-optimistic-locking-failure"))
+                   .andExpect(status().isConflict())
+                   .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_PROBLEM_JSON))
+                   .andExpect(jsonPath("title").value("Conflict"))
+                   .andExpect(jsonPath("type").value("https://example.org/optimistic-locking-error"))
+                   .andExpect(jsonPath("detail").value("Object of class [com.example.user.User] with identifier [1]: optimistic locking failed"))
+                   .andExpect(jsonPath("persistentClassName").value("com.example.user.User"))
+                   .andExpect(jsonPath("identifier").value("1"))
+            ;
+        }
     }
 
     @RestController

--- a/src/test/java/io/github/wimdeblauwe/errorhandlingspringbootstarter/handler/ServerErrorExceptionHandlerTest.java
+++ b/src/test/java/io/github/wimdeblauwe/errorhandlingspringbootstarter/handler/ServerErrorExceptionHandlerTest.java
@@ -1,6 +1,7 @@
 package io.github.wimdeblauwe.errorhandlingspringbootstarter.handler;
 
 
+import io.github.wimdeblauwe.errorhandlingspringbootstarter.ErrorHandlingProperties;
 import io.github.wimdeblauwe.errorhandlingspringbootstarter.reactive.ReactiveErrorHandlingConfiguration;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -9,6 +10,7 @@ import org.springframework.context.annotation.Import;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.web.reactive.server.WebTestClient;
 import org.springframework.test.web.reactive.server.assertj.WebTestClientResponse;
 
@@ -23,6 +25,7 @@ import static org.assertj.core.api.Assertions.assertThat;
         controllers = ServerErrorExceptionHandlerTestController.class
 )
 @Import(ReactiveErrorHandlingConfiguration.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
 class ServerErrorExceptionHandlerTest {
 
     @Autowired
@@ -41,6 +44,29 @@ class ServerErrorExceptionHandlerTest {
 
         var bodyJson = assertThat(response).bodyJson();
         bodyJson.extractingPath("code").isEqualTo("SERVER_ERROR");
+        bodyJson.extractingPath("parameterName").isEqualTo("id");
+        bodyJson.extractingPath("parameterType").isEqualTo("String");
+        bodyJson.extractingPath("methodName").isEqualTo("pathVariable");
+        bodyJson.extractingPath("methodClassName").isEqualTo("ServerErrorExceptionHandlerTestController");
+    }
+
+    @Test
+    @WithMockUser
+    void testProblemDetailFormat(@Autowired ErrorHandlingProperties properties) {
+        properties.setUseProblemDetailFormat(true);
+        WebTestClient.ResponseSpec spec = webTestClient.get()
+                                                       .uri("/path-variable")
+                                                       .accept(MediaType.APPLICATION_JSON)
+                                                       .exchange();
+        WebTestClientResponse response = WebTestClientResponse.from(spec);
+        assertThat(response).hasStatus(HttpStatus.INTERNAL_SERVER_ERROR);
+        assertThat(response).hasContentType(MediaType.APPLICATION_PROBLEM_JSON);
+
+        var bodyJson = assertThat(response).bodyJson();
+
+        bodyJson.extractingPath("title").isEqualTo("Internal Server Error");
+        bodyJson.extractingPath("type").isEqualTo("server-error");
+        bodyJson.extractingPath("detail").isEqualTo("500 INTERNAL_SERVER_ERROR \"id\"");
         bodyJson.extractingPath("parameterName").isEqualTo("id");
         bodyJson.extractingPath("parameterType").isEqualTo("String");
         bodyJson.extractingPath("methodName").isEqualTo("pathVariable");

--- a/src/test/java/io/github/wimdeblauwe/errorhandlingspringbootstarter/handler/ServerErrorExceptionHandlerTest.java
+++ b/src/test/java/io/github/wimdeblauwe/errorhandlingspringbootstarter/handler/ServerErrorExceptionHandlerTest.java
@@ -77,5 +77,28 @@ class ServerErrorExceptionHandlerTest {
             bodyJson.extractingPath("methodName").isEqualTo("pathVariable");
             bodyJson.extractingPath("methodClassName").isEqualTo("ServerErrorExceptionHandlerTestController");
         }
+
+        @Test
+        @WithMockUser
+        void testProblemDetailFormatWithoutKebabCase(@Autowired ErrorHandlingProperties properties) throws Exception {
+            properties.setProblemDetailConvertToKebabCase(false);
+            WebTestClient.ResponseSpec spec = webTestClient.get()
+                                                           .uri("/path-variable")
+                                                           .accept(MediaType.APPLICATION_JSON)
+                                                           .exchange();
+            WebTestClientResponse response = WebTestClientResponse.from(spec);
+            assertThat(response).hasStatus(HttpStatus.INTERNAL_SERVER_ERROR);
+            assertThat(response).hasContentType(MediaType.APPLICATION_PROBLEM_JSON);
+
+            var bodyJson = assertThat(response).bodyJson();
+
+            bodyJson.extractingPath("title").isEqualTo("Internal Server Error");
+            bodyJson.extractingPath("type").isEqualTo("SERVER_ERROR");
+            bodyJson.extractingPath("detail").isEqualTo("500 INTERNAL_SERVER_ERROR \"id\"");
+            bodyJson.extractingPath("parameterName").isEqualTo("id");
+            bodyJson.extractingPath("parameterType").isEqualTo("String");
+            bodyJson.extractingPath("methodName").isEqualTo("pathVariable");
+            bodyJson.extractingPath("methodClassName").isEqualTo("ServerErrorExceptionHandlerTestController");
+        }
     }
 }

--- a/src/test/java/io/github/wimdeblauwe/errorhandlingspringbootstarter/handler/ServerErrorExceptionHandlerTest.java
+++ b/src/test/java/io/github/wimdeblauwe/errorhandlingspringbootstarter/handler/ServerErrorExceptionHandlerTest.java
@@ -3,6 +3,7 @@ package io.github.wimdeblauwe.errorhandlingspringbootstarter.handler;
 
 import io.github.wimdeblauwe.errorhandlingspringbootstarter.ErrorHandlingProperties;
 import io.github.wimdeblauwe.errorhandlingspringbootstarter.reactive.ReactiveErrorHandlingConfiguration;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.webflux.test.autoconfigure.WebFluxTest;
@@ -11,6 +12,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.reactive.server.WebTestClient;
 import org.springframework.test.web.reactive.server.assertj.WebTestClientResponse;
 
@@ -50,26 +52,30 @@ class ServerErrorExceptionHandlerTest {
         bodyJson.extractingPath("methodClassName").isEqualTo("ServerErrorExceptionHandlerTestController");
     }
 
-    @Test
-    @WithMockUser
-    void testProblemDetailFormat(@Autowired ErrorHandlingProperties properties) {
-        properties.setUseProblemDetailFormat(true);
-        WebTestClient.ResponseSpec spec = webTestClient.get()
-                                                       .uri("/path-variable")
-                                                       .accept(MediaType.APPLICATION_JSON)
-                                                       .exchange();
-        WebTestClientResponse response = WebTestClientResponse.from(spec);
-        assertThat(response).hasStatus(HttpStatus.INTERNAL_SERVER_ERROR);
-        assertThat(response).hasContentType(MediaType.APPLICATION_PROBLEM_JSON);
+    @Nested
+    @TestPropertySource(properties = "error.handling.use-problem-detail-format=true")
+    class ProblemDetailsFormatTests {
 
-        var bodyJson = assertThat(response).bodyJson();
+        @Test
+        @WithMockUser
+        void testProblemDetailFormat() {
+            WebTestClient.ResponseSpec spec = webTestClient.get()
+                                                           .uri("/path-variable")
+                                                           .accept(MediaType.APPLICATION_JSON)
+                                                           .exchange();
+            WebTestClientResponse response = WebTestClientResponse.from(spec);
+            assertThat(response).hasStatus(HttpStatus.INTERNAL_SERVER_ERROR);
+            assertThat(response).hasContentType(MediaType.APPLICATION_PROBLEM_JSON);
 
-        bodyJson.extractingPath("title").isEqualTo("Internal Server Error");
-        bodyJson.extractingPath("type").isEqualTo("server-error");
-        bodyJson.extractingPath("detail").isEqualTo("500 INTERNAL_SERVER_ERROR \"id\"");
-        bodyJson.extractingPath("parameterName").isEqualTo("id");
-        bodyJson.extractingPath("parameterType").isEqualTo("String");
-        bodyJson.extractingPath("methodName").isEqualTo("pathVariable");
-        bodyJson.extractingPath("methodClassName").isEqualTo("ServerErrorExceptionHandlerTestController");
+            var bodyJson = assertThat(response).bodyJson();
+
+            bodyJson.extractingPath("title").isEqualTo("Internal Server Error");
+            bodyJson.extractingPath("type").isEqualTo("server-error");
+            bodyJson.extractingPath("detail").isEqualTo("500 INTERNAL_SERVER_ERROR \"id\"");
+            bodyJson.extractingPath("parameterName").isEqualTo("id");
+            bodyJson.extractingPath("parameterType").isEqualTo("String");
+            bodyJson.extractingPath("methodName").isEqualTo("pathVariable");
+            bodyJson.extractingPath("methodClassName").isEqualTo("ServerErrorExceptionHandlerTestController");
+        }
     }
 }


### PR DESCRIPTION
This PR adds support for [ProblemDetail](https://docs.spring.io/spring-framework/reference/web/webmvc/mvc-ann-rest-exceptions.html).

It is disabled by default and can be enabled via the `error.handling.use-problem-detail-format=true` property.

Mapping is done like this:

* `type`: Is the `code`, but converted to kebab case (e.g. `validation-failed`). Optionally, you can give the url a prefix via `error.handling.problem-detail-type-prefix` property (e.g. `https://example.com/validation-failed`).
* `title`: Is generated automatically by the Spring `ProblemDetail` class.
* `detail`: Is the `message`.

Additional properties (added via `@ResponseErrorProperty`) are also added to the result. For validation errors, the `fieldErrors` and `globalErrors` will also be present.

Fixes #59