### PR TITLE
build: bump Spring Boot to 4.1.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>4.0.2</version>
+        <version>4.1.0</version>
         <relativePath /> <!-- lookup parent from repository -->
     </parent>
     <groupId>io.github.wimdeblauwe</groupId>


### PR DESCRIPTION
Closes #132

## What
Bumps the Spring Boot version used by this starter to 4.1.0.

## Changes
- Updated `spring-boot-starter-parent` in `pom.xml`

## Testing
- `./mvnw clean verify` passes locally